### PR TITLE
improvements to the hg provider

### DIFF
--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -13,6 +13,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, :parent => Puppet::Provider::Vcsrepo) d
     else
       clone_repository(@resource.value(:revision))
     end
+    update_owner
   end
 
   def working_copy_exists?
@@ -72,6 +73,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, :parent => Puppet::Provider::Vcsrepo) d
       end
       hg('update', '--clean', '-r', desired)
     end
+    update_owner
   end
 
   private
@@ -88,6 +90,12 @@ Puppet::Type.type(:vcsrepo).provide(:hg, :parent => Puppet::Provider::Vcsrepo) d
     args.push(@resource.value(:source),
               @resource.value(:path))
     hg(*args)
+  end
+
+  def update_owner
+    if @resource.value(:owner) or @resource.value(:group)
+      set_ownership
+    end
   end
 
 end


### PR DESCRIPTION
The first commit is similar to "Fixed bomb out with an error concerning working_copy_exists? not
being defined for svn repos" (e572002ab6b9ce15d446ffdab19353d4da18849c), but for hg.

After that was fixed, Puppet still complained about `latest{,?}` not being defined (since we do indicate that ProviderHG `has_features :reference_tracking`), so I added those and `ensure => latest` now works properly...sort of. It's no worse than it was before, but it won't work in the case where a manifest defines the `revision` attribute as a tag _name_ instead of nodeid. Why was this commit (c714947908b69c538ea9d050d4375e2b3f19e7ac) added in the first place? I don't know when you'd ever want the `revision` method to return the tag name instead of the nodeid.

The logic for the `revision` method would bomb if the "desired" revision was nil, so I re-structured that conditional to flow properly.

Last, I added basic support for setting the owner/group on hg repos, although it won't detect ownership changes, it will only set them when it updates the repo to a different revision (the same limitation the git provider currently has).
