### PR TITLE
Bug Fix: Some ownerships in .git directory are 'root' after vcsrepo's retrieve is called

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -96,6 +96,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def update_references
     at_path do
       git_with_identity('fetch', '--tags', 'origin')
+      update_owner_and_excludes
     end
   end
 
@@ -262,6 +263,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
       end
       current = @resource.value(:revision) if current == canonical
     end
+    update_owner_and_excludes
     return current
   end
 


### PR DESCRIPTION
update_preferences and get_revision are called when the type is retrieve'd. Without this patch, the ownerships
for any .git metafiles fetch'd durring the retrieve will be owned by root. This patch fixes that by invoking update_owner_and_excludes after fetch'ng
