### PR TITLE
Added missing 'working_copy_exists?' method.

### DIFF
--- a/lib/puppet/provider/vcsrepo/bzr.rb
+++ b/lib/puppet/provider/vcsrepo/bzr.rb
@@ -15,8 +15,12 @@ Puppet::Type.type(:vcsrepo).provide(:bzr, :parent => Puppet::Provider::Vcsrepo) 
     end
   end
 
-  def exists?
+  def working_copy_exists?
     File.directory?(File.join(@resource.value(:path), '.bzr'))
+  end
+
+  def exists?
+    working_copy_exists?
   end
 
   def destroy


### PR DESCRIPTION
Hi,

I had the following error:

err: //graphite/Vcsrepo[/usr/src/graphite/]: Failed to retrieve current state of resource: undefined method `working_copy_exists?' for #Puppet::Type::Vcsrepo::ProviderBzr:0x7f840de43598

This patch corrects this by copying what is done in the other providers.
