### PR TITLE
Add default user to run git as.

### DIFF
--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -135,6 +135,7 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :user do
     desc "The user to run for repository operations"
+    defaultto 'root'
   end
 
   newparam :excludes do


### PR DESCRIPTION
Add a default to the user parameter of root, which is the user that
  the git commands would have ran in previously versions of this module.

  Without this an upgrade to the lastest release would cause syntax
  error all over a person's code base and provide no benefit.
