### PR TITLE
Replace pull with fetch in update_references.

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -97,7 +97,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def update_references
     at_path do
       checkout
-      git_with_identity('pull', @resource.value(:remote))
+      git_with_identity('fetch', @resource.value(:remote))
+      git_with_identity('fetch', '--tags', @resource.value(:remote))
       update_owner_and_excludes
     end
   end


### PR DESCRIPTION
Download all refs.

  Previous implementation would do a pull but configured to do so
  without a branch, this trew an error and caused the run to fail.
