### PR TITLE
Add support for more svn features

### DIFF
--- a/lib/puppet/provider/vcsrepo.rb
+++ b/lib/puppet/provider/vcsrepo.rb
@@ -10,7 +10,9 @@ class Puppet::Provider::Vcsrepo < Puppet::Provider
   def set_ownership
     owner = @resource.value(:owner) || nil
     group = @resource.value(:group) || nil
+    mode  = @resource.value(:mode).to_i(8) || nil
     FileUtils.chown_R(owner, group, @resource.value(:path))
+    FileUtils.chmod_R(mode, @resource.value(:path))
   end
 
   def path_exists?

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:vcsrepo) do
           provider.update_references
         end
         if provider.respond_to?(:latest?)
-            reference = provider.latest || provider.revision
+          reference = provider.latest || provider.revision
         else
           reference = resource.value(:revision) || provider.revision
         end
@@ -121,6 +121,15 @@ Puppet::Type.newtype(:vcsrepo) do
     desc "The group/gid that owns the repository files"
   end
 
+  newparam(:mode) do
+    desc "The octal mode of the repository files"
+    validate do |value|
+      if String(value).oct == 0
+        raise ArgumentError, "Permissions mode needs to be an octal number"
+      end
+    end
+  end
+
   newparam(:excludes) do
     desc "Files to be excluded from the repository"
   end
@@ -151,8 +160,24 @@ Puppet::Type.newtype(:vcsrepo) do
   newparam :identity, :required_features => [:ssh_identity] do
     desc "SSH identity file"
   end
-  
+
   newparam :module, :required_features => [:modules] do
     desc "The repository module to manage"
+  end
+
+  newparam(:export) do
+    desc "Export SVN files rather than checkout"
+    newvalues(:true, :false)
+    defaultto false
+  end
+
+  newparam(:sparse) do
+    desc "Sparse checkout"
+    newvalues(:true, :false) 
+    defaultto false
+  end
+
+  newparam(:filename) do
+    desc "Single file to checkout"
   end
 end


### PR DESCRIPTION
Extended svn provider to allow for sparse checkout of repositories
which in turn allows single files to be checked out. Alternatively, an
export can now be specified to keep the resulting files out of version
control.

To add these features most of the svn provider had to be rewritten to
account for the case of a single file checkout. The specified path
value is now used directly rather than relying on the at_path function
to figure out revision details.

File permissions can now be changed using an added mode parameter and
specifying an octal mode. Finally, if credentials are specified then
automatically trust server certificate. This prevents the checkout from
failing if the server uses an untrusted cert.
