### PR TITLE
(#16495, #15660) Fix regression for notifications and pulls on git provider

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -96,8 +96,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def update_references
     at_path do
-      checkout
-      git_with_identity('pull', @resource.value(:remote))
+      git_with_identity('fetch', @resource.value(:remote))
+      git_with_identity('fetch', '--tags', @resource.value(:remote))
       update_owner_and_excludes
     end
   end


### PR DESCRIPTION
The last merge: 4d2942edc26e7cd144a3178a1a7f6470ea401345 brought some
regression that this patch should hopefully fix.

Firstly, the tool no longer supported updating a branch as the syntax for git
pull on anything but a branch was invalid.

This also removes the extra call to 'checkout' which was causing behaviour
to occur without notifying puppet, thus causing subscription notifications
to not fire.
