### PR TITLE
Add support for existing SVN master repositories (issue #8331)

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -4,7 +4,8 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   desc "Supports Subversion repositories"
 
   optional_commands :svn      => 'svn',
-           :svnadmin => 'svnadmin'
+           :svnadmin => 'svnadmin',
+           :svnlook  => 'svnlook'
 
   defaultfor :svn => :exists
   has_features :filesystem_types, :reference_tracking, :basic_auth
@@ -21,7 +22,17 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def working_copy_exists?
-    File.directory?(File.join(@resource.value(:path), '.svn'))
+    if File.directory?(@resource.value(:path))
+      if File.directory?(File.join(@resource.value(:path), '.svn'))
+        return true
+      end
+      if svnlook('uuid',@resource.value(:path))
+        return true
+      end
+    end
+    return false
+  end
+
   end
 
   def exists?


### PR DESCRIPTION
Pull request related to issue #8331.
I have added support into the exists? method (actually working_copy_exists?) for checking if the path is a master repository, using svnlook. It should be ok in most cases, since svnlook comes with svnadmin in nearly every distribution.
