### PR TITLE
Replace references to Reductive Labs with Puppet Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Copyright (C) 2010 Reductive Labs Inc.
+Copyright (C) 2010-2012 Puppet Labs Inc.
 
-Reductive Labs can be contacted at: info@reductivelabs.com
+Puppet Labs can be contacted at: info@puppetlabs.com
 
 This program and entire repository is free software; you can
 redistribute it and/or modify it under the terms of the GNU

--- a/README.BZR.markdown
+++ b/README.BZR.markdown
@@ -44,4 +44,4 @@ More Examples
 
 For examples you can run, see `examples/bzr/`
 
-[1]: http://docs.reductivelabs.com/references/stable/metaparameter.html#require
+[1]: http://docs.puppetlabs.com/references/stable/metaparameter.html#require

--- a/README.CVS.markdown
+++ b/README.CVS.markdown
@@ -53,4 +53,4 @@ More Examples
 
 For examples you can run, see `examples/cvs/`
 
-[1]: http://docs.reductivelabs.com/references/stable/metaparameter.html#require
+[1]: http://docs.puppetlabs.com/references/stable/metaparameter.html#require

--- a/README.GIT.markdown
+++ b/README.GIT.markdown
@@ -66,5 +66,5 @@ More Examples
 
 For examples you can run, see `examples/git/`
 
-[1]: http://docs.reductivelabs.com/references/stable/metaparameter.html#require
+[1]: http://docs.puppetlabs.com/references/stable/metaparameter.html#require
 

--- a/README.HG.markdown
+++ b/README.HG.markdown
@@ -52,4 +52,4 @@ More Examples
 
 For examples you can run, see `examples/hg/`
 
-[1]: http://docs.reductivelabs.com/references/stable/metaparameter.html#require
+[1]: http://docs.puppetlabs.com/references/stable/metaparameter.html#require

--- a/README.SVN.markdown
+++ b/README.SVN.markdown
@@ -44,4 +44,4 @@ More Examples
 
 For examples you can run, see `examples/svn/`
 
-[1]: http://docs.reductivelabs.com/references/stable/metaparameter.html#require
+[1]: http://docs.puppetlabs.com/references/stable/metaparameter.html#require


### PR DESCRIPTION
Previous to this commit the documentation and license files referred
to Reductive Labs and docs.reductivelabs.com. This commit updates
those files to refer to Puppet Labs and docs.puppetlabs.com.
