### PR TITLE
Repo directory not created as specified, non-root user; "git init" then fails

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -141,7 +141,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     else
       # normal init
       if @resource.value(:user)
-        su(@resource.value(:user), '-c', "mkdir #{@resource.value(:user)}")
+        su(@resource.value(:user), '-c', "mkdir #{@resource.value(:path)}")
       else
         FileUtils.mkdir(@resource.value(:path))
       end


### PR DESCRIPTION
The following snippet:

``` puppet
vcsrepo { "/home/git/bind.git":
  ensure   => bare,
  provider => git,
  user     => 'git',
}
```

Results in 

```
Error: Execution of '/bin/su git -c git init --bare' returned 1: /home/git/bind.git/refs: Permission denied

Error: /Stage[main]/Bind::Git/Vcsrepo[/home/git/bind.git]/ensure: change from absent to bare failed: Execution of '/bin/su git -c git init --bare' returned 1: /home/git/bind.git/refs: Permission denied
```

This is because /home/git/bind.git is created root:root, but "git init" is run as the specified user:

```
> ls -l /home/git
total 4
drwxr-xr-x 2 root root 4096 Dec 28 07:44 bind.git
```

I think the attached commits fix this - thanks for considering them.

-Andy
