### PR TITLE
Fix for issue #48

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -258,7 +258,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     end
     current = at_path { git_with_identity('rev-parse', rev).strip }
     if @resource.value(:revision)
-      if local_branch_revision? or tag_reviosion?
+      if local_branch_revision? or tag_revision?
         canonical = at_path { git_with_identity('rev-parse', @resource.value(:revision)).strip }
       elsif remote_branch_revision?
         canonical = at_path { git_with_identity('rev-parse', "#{@resource.value(:remote)}/" + @resource.value(:revision)).strip }


### PR DESCRIPTION
Hi!

I've fixed issue with ensure=>latest for tag revision. Now if revision is tag, 'latest' method fetches remote tags via get_revision method and then does git rev-parse <tag_name>.
It is working for my env.
