### PR TITLE
ensure latest does git checkout on every agent run

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -42,7 +42,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     if branch == 'master'
       return get_revision("#{@resource.value(:remote)}/HEAD")
     elsif branch == '(no branch)'
-      return get_revision('HEAD')
+      if @resource.value(:revision) and tag_revision?
+        return get_revision(@resource.value(:revision))
+      else
+        return get_revision('HEAD')
+      end
     else
       return get_revision("#{@resource.value(:remote)}/%s" % branch)
     end
@@ -255,7 +259,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     end
     current = at_path { git_with_identity('rev-parse', rev).strip }
     if @resource.value(:revision)
-      if local_branch_revision?
+      if local_branch_revision? or tag_revision?
         canonical = at_path { git_with_identity('rev-parse', @resource.value(:revision)).strip }
       elsif remote_branch_revision?
         canonical = at_path { git_with_identity('rev-parse', "#{@resource.value(:remote)}/" + @resource.value(:revision)).strip }


### PR DESCRIPTION
Hi!

I'm writing the following resource:

```
 vcsrepo { "/repopath":
    ensure => latest,
    user => auto,
    owner => auto,
    group => auto,
    provider => git,
    source => 'file:///share/repo.git',
    revision => 'release'
}
```

Branch of git workdir is 'no branch' since 'release' is a remote tag reference.
Every time puppet agent is running, puppet runs 'git checkout --force', but it should just check remote and local refs, and only if it diffs checkout new version. 

Log messages:

```
Jan 11 16:30:30 php4-lib2 puppet-agent[30742]: Applying configuration version '1357905227'
Jan 11 16:30:32 php4-lib2 puppet-agent[30742]: (/Stage[main]/Admingit/Vcsrepo[/repopath]/ensure) Updating to latest '89e6c4b7a74335ad03ef80ac8a7a1269333272ac' revision
Jan 11 16:30:33 php4-lib2 puppet-agent[30742]: (/Stage[main]/Admingit/Vcsrepo[/repopath]/ensure) ensure changed 'present' to 'latest'
Jan 11 16:30:33 php4-lib2 puppet-agent[30742]: Finished catalog run in 3.65 seconds
```
