### PR TITLE
Allow non-root users to clone a repo

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -115,7 +115,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     end
     if !File.exist?(File.join(@resource.value(:path), '.git'))
       args.push(source, path)
-      git_with_identity(*args)
+      Dir.chdir("/") do
+        git_with_identity(*args)
+      end
     else
       notice "Repo has already been cloned"
     end


### PR DESCRIPTION
Without this, git will report that it can't change back to /root

This is a rework of @xgoat's pull request at https://github.com/puppetlabs/puppetlabs-vcsrepo/pull/42
