### PR TITLE
Add support for configurable tmp dir for git-helper wrapper

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -291,7 +291,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def git_with_identity(*args)
     if @resource.value(:identity)
-      Tempfile.open('git-helper') do |f|
+      tmp_dir = @resource.value(:tmp_dir) || '/tmp'
+      Tempfile.open('git-helper', tmp_dir) do |f|
         f.puts '#!/bin/sh'
         f.puts "exec ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no -i #{@resource.value(:identity)} $*"
         f.close

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -38,16 +38,16 @@ Puppet::Type.newtype(:vcsrepo) do
       @should ||= []
 
       case should
-        when :present
-          return true unless [:absent, :purged, :held].include?(is)
-        when :latest
-          if is == :latest
-            return true
-          else
-            return false
-          end
-		when :bare
-		  return is == :bare
+      when :present
+        return true unless [:absent, :purged, :held].include?(is)
+      when :latest
+        if is == :latest
+          return true
+        else
+          return false
+        end
+      when :bare
+        return is == :bare
       end
     end
 
@@ -57,7 +57,7 @@ Puppet::Type.newtype(:vcsrepo) do
     end
 
     newvalue :bare, :required_features => [:bare_repositories] do
-	  if !provider.exists?
+      if !provider.exists?
         provider.create
       end
     end
@@ -166,6 +166,10 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :identity, :required_features => [:ssh_identity] do
     desc "SSH identity file"
+  end
+
+  newparam :tmp_dir, :required_features => [:ssh_identity] do
+    desc "Temp directory for generated ssh wrapper"
   end
 
   newparam :module, :required_features => [:modules] do


### PR DESCRIPTION
Currently if you are using the git provider and specify a custom
identity, vcsrepo will try and create a wrapper ssh script in the /tmp
directory. In many production setups, /tmp is mounted with noexec,
meaning that this wrapper script will not work. To get around this
people should be able to define a custom tmp directory for the wrapper.
