### PR TITLE
Improve Git SSH usage documentation

### DIFF
--- a/README.GIT.markdown
+++ b/README.GIT.markdown
@@ -76,9 +76,15 @@ Keep the repository at the latest revision (note: this will always overwrite loc
 For sources that use SSH (eg, `username@server:...`)
 ----------------------------------------------------
 
-Manage your SSH keys with Puppet and use `require` in your `vcsrepo`
-to ensure they are present.  For more information, see the `require`
-metaparameter documentation[1].
+If your SSH key is associated with a user, simply fill the `user` parameter to use his keys.
+
+Example:
+
+    user => 'toto'  # will use toto's $HOME/.ssh setup
+
+
+Otherwise, manage your SSH keys with Puppet and use `require` in your `vcsrepo` to ensure they are present.
+For more information, see the `require` metaparameter documentation[1].
 
 More Examples
 -------------


### PR DESCRIPTION
The documentation regarding SSH is misleading.
If I'm using SSH and the private key is associated with a user (common use-case, i.e. the private key is in `~/.ssh/id_rsa`), then I should **not** use the `identity` parameter, as any other user than the one who has the key may access it, but use the `user` parameter to trigger an `su`.

This changeset aims to make this clearer.
