### PR TITLE
Adding svn configuration parameter, and docs

### DIFF
--- a/README.SVN.markdown
+++ b/README.SVN.markdown
@@ -32,6 +32,21 @@ You can provide a specific `revision`:
         revision => '1234'
     }
 
+
+Using a specified Subversion configuration directory 
+-----------------------------
+
+Provide a `configuration` parameter which should be a directory path on the local system where your svn configuration
+files are.  Typically, it is /path/to/.subversion:
+
+    vcsrepo { "/path/to/repo":
+        ensure        => present,
+        provider      => svn,
+        source        => "svn://svnrepo/hello/branches/foo",
+        configuration => "/path/to/.subversion"
+    }
+
+
 For sources that use SSH (eg, `svn+ssh://...`)
 ----------------------------------------------
 

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   optional_commands :svn      => 'svn',
                     :svnadmin => 'svnadmin'
 
-  has_features :filesystem_types, :reference_tracking, :basic_auth
+  has_features :filesystem_types, :reference_tracking, :basic_auth, :configuration
 
   def create
     if !@resource.value(:source)
@@ -53,6 +53,10 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
       args.push('--force')
     end
 
+    if @resource.value(:configuration)
+      args.push('--config-dir', @resource.value(:configuration))
+    end
+    
     return args
   end
 

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -30,6 +30,9 @@ Puppet::Type.newtype(:vcsrepo) do
 
   feature :multiple_remotes,
           "The repository tracks multiple remote repositories"
+  
+  feature :configuration,
+	  "The configuration directory to use"
 
   ensurable do
     attr_accessor :latest
@@ -175,6 +178,10 @@ Puppet::Type.newtype(:vcsrepo) do
   newparam :remote, :required_features => [:multiple_remotes] do
     desc "The remote repository to track"
     defaultto "origin"
+  end
+  
+  newparam :configuration, :required_features => [:configuration]  do
+    desc "The configuration directory to use"
   end
 
 end


### PR DESCRIPTION
I added a new parameter that allows you to specify a configuration directory where svn configurations such as ssl certs, inheritance options, user options, ignore information, etc. can be contained. The option is --config-dir for svn. It is an optional parameter that can offer greater flexibility when integrating this module into and existing svn setup.
