### PR TITLE
added support for changing upstream repo url - rebase of #74

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -85,7 +85,11 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def revision=(desired)
-    args = buildargs.push('switch', '-r', desired, @resource.value(:source))
+    args = if @resource.value(:source)
+             buildargs.push('switch', '-r', desired, @resource.value(:source))
+           else
+             buildargs.push('update', '-r', desired)
+           end
     at_path do
       svn(*args)
     end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -66,16 +66,29 @@ describe_provider :vcsrepo, :svn, :resource => {:path => '/tmp/vcsrepo'} do
   end
 
   describe "setting the revision property" do
+    before do
+      @revision = '30'
+    end
+    resource_without :source do
+      it "should use 'svn update'" do
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'update', '-r', @revision)
+        provider.revision = @revision
+      end
+    end
+  end
+
+  describe "setting the revision property and repo source" do
+    before do
+      @revision = '30'
+    end
     resource_with :source do
-     before do
-       @revision = '30'
-     end
-     it "should use 'svn switch'" do
-       expects_chdir
-       provider.expects(:svn).with('--non-interactive', 'switch', '-r', @revision, 'an-unimportant-value')
-       provider.revision = @revision
-     end
-   end
+      it "should use 'svn switch'" do
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'switch', '-r', @revision, 'an-unimportant-value')
+        provider.revision = @revision
+      end
+    end
   end
 
 end


### PR DESCRIPTION
added checks that the URL of the WC matches the URL from the manifest

changed from using "update" to "switch"

rebase of #74
