### PR TITLE
Implement ssh-agent forwarding for git remotes

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -4,9 +4,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   desc "Supports Git repositories"
 
   ##TODO modify the commands below so that the su - is included
-  optional_commands :git => 'git',
-                    :su  => 'su'
-  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user
+  optional_commands :git       => 'git',
+                    :su        => 'su',
+                    :ssh_agent => 'ssh-agent'
+  has_features :bare_repositories, :reference_tracking, :ssh_identity, :forward_ssh_agent, :multiple_remotes, :user
 
   def create
     if !@resource.value(:source)
@@ -299,16 +300,36 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def git_with_identity(*args)
     if @resource.value(:identity)
+      do_forward_ssh_agent = @resource.value(:forward_ssh_agent)
       Tempfile.open('git-helper') do |f|
+        ssh_command = []
+        ssh_command << 'exec' << 'ssh' \
+                    << '-oStrictHostKeyChecking=no' \
+                    << '-oPasswordAuthentication=no' \
+                    << '-oKbdInteractiveAuthentication=no' \
+                    << '-oChallengeResponseAuthentication=no' \
+                    << '-oConnectTimeout=120'
+        if do_forward_ssh_agent
+          ssh_command << '-oForwardAgent=yes'
+        else
+          ssh_command << "-i #{@resource.value(:identity)}"
+        end
+        ssh_command << '$*'
+
         f.puts '#!/bin/sh'
-        f.puts "exec ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no -oConnectTimeout=120 -i #{@resource.value(:identity)} $*"
+        f.puts "ssh-add #{@resource.value(:identity)}" if do_forward_ssh_agent
+        f.puts ssh_command.join(' ')
         f.close
 
         FileUtils.chmod(0755, f.path)
         env_save = ENV['GIT_SSH']
         ENV['GIT_SSH'] = f.path
 
-        ret = git(*args)
+        if do_forward_ssh_agent
+          ret = ssh_agent('git', *args)
+        else
+          ret = git(*args)
+        end
 
         ENV['GIT_SSH'] = env_save
 

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -22,6 +22,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :ssh_identity,
           "The provider supports a configurable SSH identity file"
 
+  feature :forward_ssh_agent,
+          "The provider supports forwarding its identity via SSH"
+
   feature :user,
           "The provider can run as a different user"
 
@@ -172,6 +175,12 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :identity, :required_features => [:ssh_identity] do
     desc "SSH identity file"
+  end
+
+  newparam :forward_ssh_agent, :required_features => [:ssh_identity, :forward_ssh_agent] do
+    desc "Should the identity be forwarded with ssh-agent?"
+    newvalues(:true, :false)
+    defaultto false
   end
 
   newparam :module, :required_features => [:modules] do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -2,6 +2,37 @@ require 'spec_helper'
 
 describe_provider :vcsrepo, :git, :resource => {:path => '/tmp/vcsrepo'} do
 
+  context 'authenticating with SSH' do
+    resource_with :source, :identity do
+      it 'should specify the identity file' do
+        expects_chdir('/')
+        expects_chdir
+        provider.expects(:git).with do
+          wrapper = IO.read(ENV['GIT_SSH'])
+          wrapper =~ /-i\s+#{resource.value(:identity)}/
+        end.at_least_once
+        provider.create
+      end
+    end
+
+    resource_with(
+      :source            => 'ssh://git@example.com/repo.git',
+      :forward_ssh_agent => true,
+      :identity          => 'foo.pem'
+    ) do
+      it 'should forward the ssh agent' do
+        expects_chdir('/')
+        expects_chdir
+        provider.expects(:ssh_agent).with do
+          wrapper = IO.read(ENV['GIT_SSH'])
+          wrapper =~ /ssh-add\s+#{resource.value(:identity)}/ &&
+            wrapper =~ /-oForwardAgent=yes/
+        end.at_least_once
+        provider.create
+      end
+    end
+  end
+
   context 'creating' do
     resource_with :source do
       resource_with :ensure => :present do


### PR DESCRIPTION
- New forward_ssh_agent feature and parameter can be used with git provider
- New feature depends on ssh_identity feature
- Add specs for git provider's ssh_identity implementation
- Add specs for new git provider functionality

Motivation:
This functionality allows gitolite's upstream functionality to be used as a read-through proxy for git remotes, although there may be other, unforeseen use cases. This change is backwards-compatible.
