### PR TITLE
Add support for --trust-server-cert in SVN provider

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
                     :svnadmin => 'svnadmin',
                     :svnlook  => 'svnlook'
 
-  has_features :filesystem_types, :reference_tracking, :basic_auth, :configuration, :trust_server_cert
+  has_features :filesystem_types, :reference_tracking, :basic_auth, :configuration, :verify_ssl
 
   def create
     if !@resource.value(:source)
@@ -52,7 +52,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
       args.push('--no-auth-cache')
     end
 
-    if @resource.value(:trust_server_cert)
+    unless @resource.value(:verify_ssl)
         args.push('--trust-server-cert')
     end
 

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -37,8 +37,8 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :cvs_rsh,
           "The provider understands the CVS_RSH environment variable"
 
-  feature :trust_server_cert,
-          "The provider supports trusting any SSL certificate issuer"
+  feature :verify_ssl,
+          "The provider supports disabling SSL certificate verifications"
 
   ensurable do
     attr_accessor :latest
@@ -194,9 +194,9 @@ Puppet::Type.newtype(:vcsrepo) do
     desc "The value to be used for the CVS_RSH environment variable."
   end
 
-  newparam :trust_server_cert do
-    desc "Wether to always trust certificate issuer or not"
-    defaultto false
+  newparam :verify_ssl do
+    desc "Wether to check SSL certificates or not"
+    defaultto true
   end
 
 end


### PR DESCRIPTION
Added suport for SVN provider's parameter "--trust-server-cert".

This parameter tells svn client to ignore the "issuer not trusted" errors when using an HTTPS repository. If it is not specified the module behaves as usual.

Usage:
vcsrepo {"my repo":
    ensure => latest,
    provider => svn,
    source => "https://svn.example.com/svn/myproject/trunk",
    basic_auth_username => 'myusername',
    basic_auth_password => 'mypassword',
    verify_ssl => false,
}

When setting "verify_ssl" = false, SVN client ignores the issuer error on SSL certificates.

Can be extended to other providers.
