### PR TITLE
Add autorequire for Package['git']

### DIFF
--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -191,4 +191,8 @@ Puppet::Type.newtype(:vcsrepo) do
     desc "The value to be used for the CVS_RSH environment variable."
   end
 
+  autorequire(:package) do
+    ['git', 'git-core']
+  end
+
 end


### PR DESCRIPTION
If the git package is being managed, it stands to reason that the git package should be installed before trying to potentially manage git repositories using vcsrepo resources.

This commit adds an autorequire to the vcsrepo type that reflects the above premise.
