### PR TITLE
Correctly handle detached head for 'latest' on latest Git versions

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def latest
     branch = on_branch?
-    if branch == '(no branch)'
+    if branch == ''
       return get_revision('HEAD')
     else
       return get_revision("#{@resource.value(:remote)}/%s" % branch)
@@ -253,7 +253,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def on_branch?
-    at_path { git_with_identity('branch', '-a') }.split(/\n/).grep(/\*/).first.to_s.gsub('*', '').strip
+    at_path { git_with_identity('rev-parse', '--abbrev-ref', 'HEAD') }
   end
 
   def tags

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -323,19 +323,19 @@ describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
     end
     context 'on master' do
       it do
-        provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_a))
+        provider.expects(:git).with('rev-parse', '--abbrev-ref', 'HEAD').returns(fixture(:git_branch_a))
         provider.latest.should == 'master'
       end
     end
     context 'no branch' do
       it do
-        provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_none))
+        provider.expects(:git).with('rev-parse', '--abbrev-ref', 'HEAD').returns(fixture(:git_branch_none))
         provider.latest.should == 'master'
       end
     end
     context 'feature/bar' do
       it do
-        provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_feature_bar))
+        provider.expects(:git).with('rev-parse', '--abbrev-ref', 'HEAD').returns(fixture(:git_branch_feature_bar))
         provider.latest.should == 'master'
       end
     end


### PR DESCRIPTION
Newer versions of Git (I'm not sure as of what version) will output the following for `git branch -a` while in a detached HEAD state:

```
$ git branch -a
* (detached from 4689c51)                                             
  master                                                              
  remotes/origin/HEAD -> origin/master
```

The first line is different than what is expected from previous Git version: "(no branch)". This patch uses rev-parse, which should work with most existing Git versions and will hopefully be immune to this problem in the future.

This patch also gets rid of "origin/HEAD", which is not a valid (and does throw an error in newer Git versions); origin/master points to the tip of master on origin, which seems to be what was desired.
