### PR TITLE
Bug fix: Git provider on_branch? retains trailing newline

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -39,10 +39,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def latest
     branch = on_branch?
-    if branch == ''
+    if !branch
       return get_revision('HEAD')
     else
-      return get_revision("#{@resource.value(:remote)}/%s" % branch)
+      return get_revision("#{@resource.value(:remote)}/#{branch}")
     end
   end
 
@@ -253,7 +253,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def on_branch?
-    at_path { git_with_identity('rev-parse', '--abbrev-ref', 'HEAD') }
+    at_path { git_with_identity('rev-parse', '--abbrev-ref', 'HEAD').chomp }
   end
 
   def tags

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -296,6 +296,18 @@ describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
     end
   end
 
+  context "retrieving the current revision" do
+    before do
+      expects_chdir
+      provider.expects(:git).with('rev-parse', '--abbrev-ref', 'HEAD').returns("foo\n")
+    end
+
+    it "will strip trailing newlines" do
+      provider.expects(:get_revision).with('origin/foo')
+      provider.latest
+    end
+  end
+
   describe 'latest?' do
     before do
       expects_chdir('/tmp/test')


### PR DESCRIPTION
I submitted a patch yesterday for using --abbrev-ref for on_branch?; unfortunately, there is a trailing newline, which causes problems when the repository already exists:

```
Error: /Stage[main]//Vcsrepo[...]: Could not evaluate: Execution of '/usr/local/bin/git rev-parse origin/master
' returned 128: fatal: ambiguous argument 'origin/master
': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
origin/master
```
