### PR TITLE
Add the option to shallow clones with git

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   ##TODO modify the commands below so that the su - is included
   optional_commands :git => 'git',
                     :su  => 'su'
-  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user
+  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth
 
   def create
     if !@resource.value(:source)
@@ -131,6 +131,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def clone_repository(source, path)
     check_force
     args = ['clone']
+    if @resource.value(:depth) and @resource.value(:depth).to_i > 0
+      args.push('--depth', @resource.value(:depth).to_s)
+    end
     if @resource.value(:ensure) == :bare
       args << '--bare'
     end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -37,6 +37,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :cvs_rsh,
           "The provider understands the CVS_RSH environment variable"
 
+  feature :depth,
+          "The provider can do shallow clones"
+
   ensurable do
     attr_accessor :latest
 
@@ -189,6 +192,10 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :cvs_rsh, :required_features => [:cvs_rsh] do
     desc "The value to be used for the CVS_RSH environment variable."
+  end
+
+  newparam :depth, :required_features => [:depth] do
+    desc "The value to be used to do a shallow clone."
   end
 
   autorequire(:package) do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -31,6 +31,20 @@ describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
       end
     end
 
+    context "with shallow clone enable" do
+      it "should execute 'git clone --depth 1'" do
+        resource[:revision] = 'only/remote'
+        resource[:depth] = 1
+        Dir.expects(:chdir).with('/').at_least_once.yields
+        Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+        provider.expects(:git).with('clone', '--depth', '1', resource.value(:source), resource.value(:path))
+        provider.expects(:update_submodules)
+        provider.expects(:git).with('branch', '-a').returns(resource.value(:revision))
+        provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+        provider.create
+      end
+    end
+
     context "with a revision that is not a remote branch" do
       it "should execute 'git clone' and 'git reset --hard'" do
         resource[:revision] = 'a-commit-or-tag'


### PR DESCRIPTION
The new parameter used to indicate that you want a shallow clone is `:depth`

This is particularly useful for big repositories or trying to clone over slow connections, I'm dealing with both problems at the moment.

Another scenario where this functionality comes handy is when you're testing puppet recipes inside vagrant, for big repos this will speed up your jobs.
