### PR TITLE
git: actually use the remote parameter

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -105,10 +105,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def update_remote_origin_url
-    current = git_with_identity('config', 'remote.origin.url')
+    current = git_with_identity('config', "remote.#{@resource.value(:remote)}.url")
     unless @resource.value(:source).nil?
       if current.nil? or current.strip != @resource.value(:source)
-        git_with_identity('config', 'remote.origin.url', @resource.value(:source))
+        git_with_identity('config', "remote.#{@resource.value(:remote)}.url", @resource.value(:source))
       end
     end
   end
@@ -136,6 +136,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     end
     if @resource.value(:ensure) == :bare
       args << '--bare'
+    end
+    if @resource.value(:remote) != 'origin'
+      args.push('--origin', @resource.value(:remote))
     end
     if !File.exist?(File.join(@resource.value(:path), '.git'))
       args.push(source, path)

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -31,6 +31,19 @@ describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
       end
     end
 
+    context "with a remote not named 'origin'" do
+        it "should execute 'git clone --origin not_origin" do
+            resource[:remote] = 'not_origin'
+            Dir.expects(:chdir).with('/').at_least_once.yields
+            Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+            provider.expects(:git).with('clone', '--origin', 'not_origin', resource.value(:source), resource.value(:path))
+            provider.expects(:update_submodules)
+            provider.expects(:git).with('branch', '-a').returns(resource.value(:revision))
+            provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+            provider.create
+        end
+    end
+
     context "with shallow clone enable" do
       it "should execute 'git clone --depth 1'" do
         resource[:revision] = 'only/remote'


### PR DESCRIPTION
When using the following sample, the provider does not use the value of remote
when cloning a repository:

```
vcsrepo {'/path/to/repo':
   ensure => 'present',
   provider => 'git',
   remote => 'test',
   source => 'git@somerepo:repo.git',
}
```

```
$ git remote
origin
```

This commit makes sure that the new repository has a remote with the
supplied value.

Closes #MODULES-430
