### PR TITLE
fix svnlook behavior with plain directories

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -24,8 +24,10 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
     if File.directory?(@resource.value(:path))
       # :path is an svn checkout
       return true if File.directory?(File.join(@resource.value(:path), '.svn'))
-      # :path is an svn server
-      return true if svnlook('uuid', @resource.value(:path))
+      if File.directory?(File.join(@resource.value(:path), 'format'))
+        # :path is an svn server
+        return true if svnlook('uuid', @resource.value(:path))
+      end
     end
     false
   end


### PR DESCRIPTION
fixes #116 - svnlook expects a sub-directory within a repository called "format".
when using svnlook within a non-repository directory this causes it to throw an error.
Adding a test for that directory before executing svnlook.
