### PR TITLE
Use `git rev-parse` to get tag canonical revision

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     return current unless @resource.value(:revision)
 
     if tag_revision?(@resource.value(:revision))
-      canonical = at_path { git_with_identity('show', @resource.value(:revision)).scan(/^commit (.*)/).to_s }
+      canonical = at_path { git_with_identity('rev-parse', @resource.value(:revision)).chomp }
     else
       # if it's not a tag, look for it as a local ref
       canonical = at_path { git_with_identity('rev-parse', '--revs-only', @resource.value(:revision)).chomp }


### PR DESCRIPTION
`git rev-parse` is preferred to get tag's canonical revision. And a side effect of this PR is to fix #112 per my test.
