### PR TITLE
Avoid checkout failure due to untracked files

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -221,7 +221,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def checkout(revision = @resource.value(:revision))
     if !local_branch_revision? && remote_branch_revision?
-      at_path { git_with_identity('checkout', '-b', revision, '--track', "#{@resource.value(:remote)}/#{revision}") }
+      at_path { git_with_identity('checkout', '--force', '-b', revision, '--track', "#{@resource.value(:remote)}/#{revision}") }
     else
       at_path { git_with_identity('checkout', '--force', revision) }
     end


### PR DESCRIPTION
- Avoid checkout to fail because of untracked files by forcing the checkout (`--force` switch)
- ~~Remove the untracked files after a 'reset hard' as I think most people expect this behavior~~
- ~~Reset after checkout in every cases for consistency~~
