### PR TITLE
Report when the repository has changed

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -49,6 +49,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def revision
     update_references
     current = at_path { git_with_identity('rev-parse', 'HEAD').chomp }
+    current << '-dirty' if at_path { git_with_identity('status', '-s').lines.count } > 0
     return current unless @resource.value(:revision)
 
     if tag_revision?(@resource.value(:revision))


### PR DESCRIPTION
Report when the repository has changed by adding the suffix '-dirty' to the revision.

The PR #127 and #128 together allows to ensure the repository is exactly on the provided revision.
That means if you request the repository to be on revision `f58357f`, it reset all changes even if the repository is already on `f58357f`.
