### PR TITLE
Ensure the repository does not differ from the provided revision

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -86,6 +86,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     # whether to reset or pull when we're ensuring latest.
     if local_branch_revision?(desired)
       reset("#{@resource.value(:remote)}/#{desired}")
+    else
+      reset(desired)
     end
     if @resource.value(:ensure) != :bare
       update_submodules

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -288,6 +288,8 @@ describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
         resource[:revision] = 'a-commit-or-tag'
         provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_a))
         provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+        provider.expects(:git).with('reset', '--hard', 'a-commit-or-tag')
+        provider.expects(:git).with('clean', '--force')
         provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_a))
         provider.expects(:git).with('branch', '-a').returns(fixture(:git_branch_a))
         provider.expects(:git).with('submodule', 'update', '--init', '--recursive')


### PR DESCRIPTION
This PR ensures your repository is exactly on the provided revision, without any changes.

**Changes:**
- Report when the repository has changed by adding the suffix '-dirty' to the revision
- Remove the untracked files after a 'reset hard' (untracked but not ignored)
- Reset after checkout in every cases for consistency

I think most of people expect their repository to be exactly on the revision they provide.
But I also understand this is an important change in behavior.
