### PR TITLE
Add -s /bin/sh to su command for git and hg

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -319,7 +319,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
         return ret
       end
     elsif @resource.value(:user) and @resource.value(:user) != Facter['id'].value
-      su(@resource.value(:user), '-c', "git #{args.join(' ')}" )
+      # set shell to external shell for su command
+      shell = ['-s', '/bin/sh'] if Facter['kernel'].value == 'Linux'
+      su(@resource.value(:user), '-c', "git #{args.join(' ')}", *shell)
     else
       git(*args)
     end

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -112,7 +112,9 @@ Puppet::Type.type(:vcsrepo).provide(:hg, :parent => Puppet::Provider::Vcsrepo) d
     end
     if @resource.value(:user) and @resource.value(:user) != Facter['id'].value
       args.map! { |a| if a =~ /\s/ then "'#{a}'" else a end }  # Adds quotes to arguments with whitespaces.
-      su(@resource.value(:user), '-c', "hg #{args.join(' ')}")
+      # set shell to external shell for su command
+      shell = ['-s', '/bin/sh'] if Facter['kernel'].value == 'Linux'
+      su(@resource.value(:user), '-c', "hg #{args.join(' ')}", *shell)
     else
       hg(*args)
     end


### PR DESCRIPTION
When a users shell is set to /bin/false or any other non-login shell
the su command in both git and hg providers will not successfully
switch to the user. This allows for detection of Linux, whos su has
'-s' argument to overwrite the shell used.

If the system is not Linux, then shell will become nil, and you can AFAIK, splat a nil.
