### PR TITLE
Ensure vagrant user/group for non-vagrant testing

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -184,6 +184,13 @@ describe 'clones a remote repo' do
   end
 
   context 'with an owner' do
+    pp = <<-EOS
+    user { 'vagrant':
+      ensure => present,
+    }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
     it 'clones a repo' do
       pp = <<-EOS
       vcsrepo { "#{tmpdir}/testrepo_owner":
@@ -206,6 +213,14 @@ describe 'clones a remote repo' do
   end
 
   context 'with a group' do
+    pp = <<-EOS
+    group { 'vagrant':
+      ensure => present,
+    }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+
     it 'clones a repo' do
       pp = <<-EOS
       vcsrepo { "/#{tmpdir}/testrepo_group":


### PR DESCRIPTION
These tests assert the vagrant user and group. When testing on non-vagrant systems these tests
will fail. Ensure that the user/group are present in order to allow the tests to pass on
other systems.
