### PR TITLE
Add optional keyfile argument to rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ end
 def check_args_for_keyfile(extra_args)
   keyfile = ''
   extra_args.each do |a|
-    keyfile = a if (`file -b #{a}`.gsub(/\n/,"").match(/ key/))
+    keyfile = a unless (`ssh-keygen -l -f #{a}`.gsub(/\n/,"").match(/is not a .*key file/))
   end
   return keyfile
 end


### PR DESCRIPTION
This addition walks over any extra arguments provided to the
rake task. If the file is a key file, it is used to set the
BEAKER_keyfile ENVIRONMENT variable for beaker-rspec and/or
the `--keyfile` command line argument for beaker as needed.

Example:

BEAKER_setfile=../vcenterhost.cfg rake beaker:rspec:test[foo,pe,'/home/myuser/.ssh/id_rsa-secret']
