### PR TITLE
Update tests for ubuntu 14.04

### DIFF
--- a/spec/acceptance/beaker_helper.rb
+++ b/spec/acceptance/beaker_helper.rb
@@ -14,5 +14,11 @@ test_name "Installing Puppet and vcsrepo module" do
     # Waiting on release of puppet_module_install in beaker
     #puppet_module_install(:source => proj_root, :module_name => 'vcsrepo')
     scp_to(hosts, proj_root, File.join(hosts.first['distmoduledir'], 'vcsrepo'))
+    gitconfig = <<-EOS
+[user]
+	email = root@localhost
+	name = root
+EOS
+    create_remote_file(host, "/root/.gitconfig", script)
   end
 end

--- a/spec/acceptance/files/create_git_repo.sh
+++ b/spec/acceptance/files/create_git_repo.sh
@@ -6,12 +6,12 @@ touch file1.txt file2.txt file3.txt
 git init
 echo 'change 1' > file1.txt
 git add file1.txt
-git tag 0.0.1
 git commit -m 'add file1'
+git tag 0.0.1
 echo 'change 2' > file2.txt
 git add file2.txt
-git tag 0.0.2
 git commit -m 'add file2'
+git tag 0.0.2
 echo 'change 3' > file3.txt
 git add file3.txt
 git commit -m 'add file3'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -34,6 +34,8 @@ RSpec.configure do |c|
           exit
         end
       end
+      shell('git config --global user.email "root@localhost"')
+      shell('git config --global user.name "root"')
     end
   end
 end


### PR DESCRIPTION
In ubuntu 14.04 git 1.9.1 is the default version, and 1.9+ fatally fail if the `user.email` and `user.name` are not set (previously it would just warn). This commit sets those up so the tests will actually run.
