### PR TITLE
Remove beaker from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
   gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
   gem 'pry',                     :require => false
-  gem 'beaker',                  :require => false
   gem 'beaker-rspec',            :require => false
   gem 'simplecov',               :require => false
 end


### PR DESCRIPTION
Having both `beaker` and `beaker-rspec` in the Gemfile results
in a dual inclusion of `beaker` as a dependency resulting in
version 2.0.0 of `beaker-rspec` being installed.

The tests for vcsrepo require the `BEAKER_setfile` ENV var, which
is only available in `beaker-rspec` 2.2.0 and above. Removing
`beaker` allows the latest version of `beaker-rspec` to be
installed, thus satisfying this requirement.
