### PR TITLE
Add patch from https://tickets.puppetlabs.com/browse/MODULES-660

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -39,10 +39,14 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def latest
     branch = on_branch?
-    if !branch
+    if branch == 'master'
+      return get_revision("#{@resource.value(:remote)}/HEAD")
+    elsif branch == '(no branch)'
       return get_revision('HEAD')
+    elsif branch =~ /\(detached from ([0-9a-z]+)\)/
+      return get_revision(Regexp.last_match(1))
     else
-      return get_revision("#{@resource.value(:remote)}/#{branch}")
+      return get_revision("#{@resource.value(:remote)}/%s" % branch)
     end
   end
 


### PR DESCRIPTION
MODULES-660 has a patch in the comment that seems to fix the issue for my installs.  This seems to be a problem for machines running older git such as RHEL/CentOS 6 on git 1.7.x.  This seems to work fine for my testing on both git 1.7.x and 1.9.x
