### PR TITLE
Change tests to not install git-daemon on debian

### DIFF
--- a/spec/acceptance/beaker/git/basic_auth/negative/basic_auth_checkout_git.rb
+++ b/spec/acceptance/beaker/git/basic_auth/negative/basic_auth_checkout_git.rb
@@ -16,7 +16,7 @@ hosts.each do |host|
   end
 
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/branch_checkout/branch_checkout_git.rb
+++ b/spec/acceptance/beaker/git/branch_checkout/branch_checkout_git.rb
@@ -13,7 +13,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/clone/clone_git.rb
+++ b/spec/acceptance/beaker/git/clone/clone_git.rb
@@ -12,7 +12,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/group_checkout/group_checkout_git.rb
+++ b/spec/acceptance/beaker/git/group_checkout/group_checkout_git.rb
@@ -13,7 +13,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/revision_checkout/revision_checkout_git.rb
+++ b/spec/acceptance/beaker/git/revision_checkout/revision_checkout_git.rb
@@ -12,7 +12,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_git.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_git.rb
@@ -12,7 +12,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/tag_checkout/tag_checkout_git.rb
+++ b/spec/acceptance/beaker/git/tag_checkout/tag_checkout_git.rb
@@ -13,7 +13,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 

--- a/spec/acceptance/beaker/git/user_checkout/user_checkout_git.rb
+++ b/spec/acceptance/beaker/git/user_checkout/user_checkout_git.rb
@@ -13,7 +13,7 @@ hosts.each do |host|
     on(host, "cd #{tmpdir} && ./create_git_repo.sh")
   end
   step 'setup - start git daemon' do
-    install_package(host, 'git-daemon')
+    install_package(host, 'git-daemon') unless host['platform'] =~ /debian|ubuntu/
     on(host, "git daemon --base-path=#{tmpdir}  --export-all --reuseaddr --verbose --detach")
   end
 


### PR DESCRIPTION
The git-daemon is not a valid package on debian based systems.
Update tests to not try installing git-daemon on debian systems.
