### PR TITLE
Define group in clone_repo_spec test

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -324,8 +324,12 @@ describe 'clones a remote repo' do
     before(:all) do
       shell("chmod 707 #{tmpdir}")
       pp = <<-EOS
+      group { 'testuser':
+        ensure => present,
+      }
       user { 'testuser':
         ensure => present,
+        groups => 'testuser',
       }
       EOS
 
@@ -388,8 +392,12 @@ describe 'clones a remote repo' do
     before(:all) do
       # create user
       pp = <<-EOS
+      group { 'testuser-ssh':
+        ensure => present,
+      }
       user { 'testuser-ssh':
         ensure => present,
+        groups => 'testuser-ssh',
         managehome => true,
       }
       EOS


### PR DESCRIPTION
A matching group is not added for a user when added on SLES 11.
This commit adds a group to the setup manifests in order to
ensure that the proper group is added to the system during the
test preparation.
