### PR TITLE
Correct shallow clone count

### DIFF
--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_file.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_file.rb
@@ -36,7 +36,7 @@ hosts.each do |host|
     end
 
     on(host, "wc -l #{tmpdir}/#{repo_name}/.git/shallow") do |res|
-      fail_test('shallow not found') unless res.stdout.include? "2 #{tmpdir}/#{repo_name}/.git/shallow"
+      fail_test('shallow not found') unless res.stdout.include? "1 #{tmpdir}/#{repo_name}/.git/shallow"
     end
   end
 

--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_git.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_git.rb
@@ -41,7 +41,7 @@ hosts.each do |host|
     end
 
     on(host, "wc -l #{tmpdir}/#{repo_name}/.git/shallow") do |res|
-      fail_test('shallow not found') unless res.stdout.include? "2 #{tmpdir}/#{repo_name}/.git/shallow"
+      fail_test('shallow not found') unless res.stdout.include? "1 #{tmpdir}/#{repo_name}/.git/shallow"
     end
   end
 

--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_https.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_https.rb
@@ -57,7 +57,7 @@ hosts.each do |host|
     end
 
     on(host, "wc -l #{tmpdir}/#{repo_name}/.git/shallow") do |res|
-      fail_test('shallow not found') unless res.stdout.include? "2 #{tmpdir}/#{repo_name}/.git/shallow"
+      fail_test('shallow not found') unless res.stdout.include? "1 #{tmpdir}/#{repo_name}/.git/shallow"
     end
   end
 

--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_scp.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_scp.rb
@@ -47,7 +47,7 @@ hosts.each do |host|
     end
 
     on(host, "wc -l #{tmpdir}/#{repo_name}/.git/shallow") do |res|
-      fail_test('shallow not found') unless res.stdout.include? "2 #{tmpdir}/#{repo_name}/.git/shallow"
+      fail_test('shallow not found') unless res.stdout.include? "1 #{tmpdir}/#{repo_name}/.git/shallow"
     end
   end
 

--- a/spec/acceptance/beaker/git/shallow_clone/shallow_clone_ssh.rb
+++ b/spec/acceptance/beaker/git/shallow_clone/shallow_clone_ssh.rb
@@ -47,7 +47,7 @@ hosts.each do |host|
     end
 
     on(host, "wc -l #{tmpdir}/#{repo_name}/.git/shallow") do |res|
-      fail_test('shallow not found') unless res.stdout.include? "2 #{tmpdir}/#{repo_name}/.git/shallow"
+      fail_test('shallow not found') unless res.stdout.include? "1 #{tmpdir}/#{repo_name}/.git/shallow"
     end
   end
 


### PR DESCRIPTION
The manifest is set to clone at a depth of 1, but checks for a shallow
depth of 2. It should either checkout a depth of 2, or only check for a
depth of 1.

This commit makes it check for a depth of 1
