### PR TITLE
Add Vagrant Wrapper to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'beaker-rspec', '~>2.2',   :require => false
   gem 'rspec', '~>2.14',         :require => false
   gem 'simplecov',               :require => false
+  gem 'vagrant-wrapper',         :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Without this line I get this error:

```
/opt/boxen/rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/bundler-1.6.2/lib/bundler/rubygems_integration.rb:252:in `block in replace_gem': vagrant-wrapper is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /opt/boxen/rbenv/versions/2.0.0-p451/bin/vagrant:22:in `<main>'
/opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/gems/beaker-1.12.2/lib/beaker/hypervisor/vagrant.rb:151:in `block in vagrant_cmd': Failed to exec 'vagrant up' (RuntimeError)
    from /opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/gems/beaker-1.12.2/lib/beaker/hypervisor/vagrant.rb:145:in `chdir'
```
