### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+2014-06-17 - Supported Release 1.0.1
+
+Summary:
+This release is the first supported release of vcsrepo. The readme has been
+greatly improved.
+
+Features:
+- Updated and expanded readme to follow readme template
+
+Fixes:
+- Remove SLES from compatability metadata
+- Unpin rspec development dependencies
+- Update acceptance level testing
+
 2014-06-04 - Version 1.0.0
 
 Summary:

--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
 name 'puppetlabs-vcsrepo'
-version '1.0.0'
+version '1.0.1'
 summary 'Manage repositories from various version control systems'
 description 'Manage repositories from various version control systems'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "puppetlabs-vcsrepo",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "source": "https://github.com/puppetlabs/puppetlabs-vcsrepo",
     "author": "Puppet Labs",
     "license": "GPLv2",


### PR DESCRIPTION
Summary:
This release is the first supported release of vcsrepo.

Fixes:
- Remove SLES from compatability metadata
- Unpin rspec development dependencies
- Update acceptance level testing
