### PR TITLE
(QENG-798) Update acceptance helpers to create distmoduledir

### DIFF
--- a/spec/acceptance/beaker_helper.rb
+++ b/spec/acceptance/beaker_helper.rb
@@ -10,16 +10,40 @@ test_name "Installing Puppet and vcsrepo module" do
       end
     end
   end
+
+  step 'Ensure we can install our module' do
+    # We ask the host to interpolate it's distmoduledir because we don't
+    # actually know it on Windows until we've let it redirect us (depending
+    # on whether we're running as a 32/64 bit process on 32/64 bit Windows
+    moduledir = on(host, "echo #{host['distmoduledir']}").stdout.chomp
+    on host, "mkdir -p #{moduledir}"
+  end
+
   step 'install module' do
-    proj_root = File.expand_path(File.join(File.dirname(__FILE__),'..','..'))
-    # Waiting on release of puppet_module_install in beaker
-    #puppet_module_install(:source => proj_root, :module_name => 'vcsrepo')
-    scp_to(hosts, proj_root, File.join(hosts.first['distmoduledir'], 'vcsrepo'))
-    gitconfig = <<-EOS
+    hosts.each do |host|
+      proj_root = File.expand_path(File.join(File.dirname(__FILE__),'..','..'))
+
+      # This require beaker 1.12.2 I believe
+      puppet_module_install(:source => proj_root, :module_name => 'vcsrepo')
+
+      case fact_on(host, 'osfamily')
+      when 'RedHat'
+        install_package(host, 'git')
+      when 'Debian'
+        install_package(host, 'git-core')
+      else
+        if !check_for_package(host, 'git')
+          puts "Git package is required for this module"
+          exit
+        end
+      end
+
+      gitconfig = <<-EOS
 [user]
 	email = root@localhost
 	name = root
 EOS
-    create_remote_file(hosts.first, "/root/.gitconfig", gitconfig)
+      create_remote_file(host, "/root/.gitconfig", gitconfig)
+    end
   end
 end


### PR DESCRIPTION
Previously we were creating the module dir on foss installs, but not on PE.
PE agents do not have a module dir deployed as part of the base PE install,
so to test on PE agents we need to create the module dir. `mkdir -p` is
idempotent, so we use it as a cudgle here. We also update the beaker_helper
and spec_helper_acceptance to contain the same installation steps for test
dependencies, warnings, and installation methods.
