### PR TITLE
Fix issue with node changing every checkin

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -52,7 +52,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     return current unless @resource.value(:revision)
 
     if tag_revision?(@resource.value(:revision))
-      canonical = at_path { git_with_identity('rev-parse', @resource.value(:revision)).chomp }
+      # git-rev-parse will give you the hash of the tag object itself rather than the commit it points to by default.
+      # Using tag^0 will return the actual commit.
+      canonical = at_path { git_with_identity('rev-parse', "#{@resource.value(:revision)}^0").chomp }
     else
       # if it's not a tag, look for it as a local ref
       canonical = at_path { git_with_identity('rev-parse', '--revs-only', @resource.value(:revision)).chomp }


### PR DESCRIPTION
git-rev-parse will give you the hash of the tag object itself rather than the commit it points to by default. Using `tag^0` will return the actual commit.

```
$ git rev-parse 0.0.152
238cc0ee29ada7069778d3711084b81b8a0ffbaa
$ git rev-parse 0.0.152^0
e6911e9ee1d589b8192ec2f6bbb6edc396ad5c2b
$ git rev-parse 0.0.152^{commit}
e6911e9ee1d589b8192ec2f6bbb6edc396ad5c2b
```
