### PR TITLE
(maint) Use `copy_module_to` in `beaker_helper.rb`

### DIFF
--- a/spec/acceptance/beaker_helper.rb
+++ b/spec/acceptance/beaker_helper.rb
@@ -25,8 +25,8 @@ test_name "Installing Puppet and vcsrepo module" do
     hosts.each do |host|
       proj_root = File.expand_path(File.join(File.dirname(__FILE__),'..','..'))
 
-      # This require beaker 1.12.2 I believe
-      puppet_module_install(:source => proj_root, :module_name => 'vcsrepo')
+      # This require beaker 1.15
+      copy_module_to(host, :source => proj_root, :module_name => 'vcsrepo')
 
       case fact_on(host, 'osfamily')
       when 'RedHat'


### PR DESCRIPTION
Previously we were using `puppet_module_install()`. Which was ported from
Beaker-RSpec. Unfortunately for our heros that method has been refactored
since this was ran last. The method `puppet_module_install()` in Beaker
installs from the public forge, while the previous behavior, installing via
scp from the current directory, has moved to the method `copy_module_to`.
This updates the helper for the beaker tests to use the updated method.

See http://jenkins-modules.delivery.puppetlabs.net/view/vcsrepo/view/1.0.x%20PE%20Next/job/modules_puppetlabs-vcsrepo_intn-sys_core-stable-enterprise-next-beaker/9/PLATFORM_CONFIG=ubuntu-1204-32mda,SLAVE_LABEL=bundler/consoleFull for the build results (currently in progress).
