### PR TITLE
Dont fail on Ruby 1.8.7

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
-require 'simplecov'
 require 'support/filesystem_helpers'
 require 'support/fixture_helpers'
 
-SimpleCov.start do
-    add_filter "/spec/"
+unless RUBY_VERSION == '1.8.7'
+  require 'simplecov'
+  SimpleCov.start do
+      add_filter "/spec/"
+  end
 end
 
 RSpec.configure do |c|

--- a/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :bzr,
     :revision => '2634',

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :cvs,
     :revision => '2634',

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -12,7 +12,6 @@ end
 branches
     end
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :git,
     :revision => '2634',

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:vcsrepo).provider(:hg) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :hg,
     :path     => '/tmp/vcsrepo',

--- a/spec/unit/puppet/provider/vcsrepo/p4_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/p4_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:vcsrepo).provider(:p4) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :p4,
     :path     => '/tmp/vcsrepo',

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Puppet::Type.type(:vcsrepo).provider(:svn) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
-    :name     => 'test',
     :ensure   => :present,
     :provider => :svn,
     :path     => '/tmp/vcsrepo',


### PR DESCRIPTION
`:name` paramater is deleted from resource creating because on Ruby 1.8.7 for some reason `:name` takes precedence over `:path`.
