### PR TITLE
Disable simplecov on Ruby 1.8.7

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,13 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
-require 'simplecov'
 require 'support/filesystem_helpers'
 require 'support/fixture_helpers'
 
-SimpleCov.start do
-    add_filter "/spec/"
+# SimpleCov does not run on Ruby 1.8.7
+unless RUBY_VERSION.to_f < 1.9
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/spec/'
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
SimpleCov requires Ruby 1.9+
