### PR TITLE
(MODULES-428) Remove dummy warning

### DIFF
--- a/lib/puppet/provider/vcsrepo/dummy.rb
+++ b/lib/puppet/provider/vcsrepo/dummy.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '..', 'vcsrepo')
 Puppet::Type.type(:vcsrepo).provide(:dummy, :parent => Puppet::Provider::Vcsrepo) do
   desc "Dummy default provider"
 
-  defaultfor :vcsrepo => :dummy
+  defaultfor :feature => :posix
 
   def working_copy_exists?
     providers = @resource.class.providers.map{|x| x.to_s}.sort.reject{|x| x == "dummy"}.join(", ") rescue "none"


### PR DESCRIPTION
Puppet started raising a warning about multiple default providers due to a change in puppet. The dummy provider exists to raise an error when `provider` is not specified because there is no way to declare `provider` as a required attribute in the type. Even passing a `provider` value did not get rid of the "multiple default providers found" warning however.

This commit causes the dummy provider to be the defacto default for all resources which do not have an explicit provider declared, as the posix feature is available on basically every operating system on which vcsrepo works. (There is no way to create an "always default" provider.)
