### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -30,11 +30,11 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
 
     describe file("#{tmpdir}/testrepo/.git/HEAD") do
-      it { should contain 'ref: refs/heads/master' }
+      it { is_expected.to contain 'ref: refs/heads/master' }
     end
   end
 
@@ -63,11 +63,11 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_sha/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
 
     describe file("#{tmpdir}/testrepo_sha/.git/HEAD") do
-      it { should contain sha }
+      it { is_expected.to contain sha }
     end
   end
 
@@ -88,7 +88,7 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_tag/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
 
     it 'should have the tag as the HEAD' do
@@ -113,11 +113,11 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_branch/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
 
     describe file("#{tmpdir}/testrepo_branch/.git/HEAD") do
-      it { should contain 'ref: refs/heads/a_branch' }
+      it { is_expected.to contain 'ref: refs/heads/a_branch' }
     end
   end
 
@@ -183,7 +183,7 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_shallow/.git/shallow") do
-      it { should be_file }
+      it { is_expected.to be_file }
     end
   end
 
@@ -229,8 +229,8 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_owner") do
-      it { should be_directory }
-      it { should be_owned_by 'vagrant' }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'vagrant' }
     end
   end
 
@@ -259,8 +259,8 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_group") do
-      it { should be_directory }
-      it { should be_grouped_into 'vagrant' }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_grouped_into 'vagrant' }
     end
   end
 
@@ -281,8 +281,15 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_excludes/.git/info/exclude") do
-      its(:content) { should match /exclude1.txt/ }
-      its(:content) { should match /exclude2.txt/ }
+      describe '#content' do
+        subject { super().content }
+        it { is_expected.to match /exclude1.txt/ }
+      end
+
+      describe '#content' do
+        subject { super().content }
+        it { is_expected.to match /exclude2.txt/ }
+      end
     end
   end
 
@@ -308,15 +315,15 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_force/folder") do
-      it { should_not be_directory }
+      it { is_expected.not_to be_directory }
     end
 
     describe file("#{tmpdir}/testrepo_force/temp.txt") do
-      it { should_not be_file }
+      it { is_expected.not_to be_file }
     end
 
     describe file("#{tmpdir}/testrepo_force/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
 
     context 'and noop' do
@@ -382,13 +389,13 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/testrepo_user") do
-      it { should be_directory }
-      it { should be_owned_by 'testuser' }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'testuser' }
     end
 
     describe file("#{tmpdir}/testrepo_user") do
-      it { should be_directory }
-      it { should be_grouped_into 'testuser' }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_grouped_into 'testuser' }
     end
   end
 

--- a/spec/acceptance/create_repo_spec.rb
+++ b/spec/acceptance/create_repo_spec.rb
@@ -26,7 +26,7 @@ describe 'create a repo' do
     end
 
     describe file("#{tmpdir}/testrepo_blank_repo/.git") do
-      it { should be_directory }
+      it { is_expected.to be_directory }
     end
   end
 
@@ -45,11 +45,11 @@ describe 'create a repo' do
     end
 
     describe file("#{tmpdir}/testrepo_bare_repo/config") do
-      it { should contain 'bare = true' }
+      it { is_expected.to contain 'bare = true' }
     end
 
     describe file("#{tmpdir}/testrepo_bare_repo/.git") do
-      it { should_not be_directory }
+      it { is_expected.not_to be_directory }
     end
   end
 
@@ -67,7 +67,7 @@ describe 'create a repo' do
     end
 
     describe file("#{tmpdir}/testrepo_bare_repo_rev") do
-      it { should_not be_directory }
+      it { is_expected.not_to be_directory }
     end
   end
 end

--- a/spec/acceptance/remove_repo_spec.rb
+++ b/spec/acceptance/remove_repo_spec.rb
@@ -25,6 +25,6 @@ describe 'remove a repo' do
   end
 
   describe file("#{tmpdir}/testrepo_deleted") do
-    it { should_not be_directory }
+    it { is_expected.not_to be_directory }
   end
 end

--- a/spec/acceptance/remove_repo_spec_noop.rb
+++ b/spec/acceptance/remove_repo_spec_noop.rb
@@ -26,6 +26,6 @@ describe 'does not remove a repo if noop' do
   end
 
   describe file("#{tmpdir}/testrepo_noop_deleted") do
-    it { should be_directory }
+    it { is_expected.to be_directory }
   end
 end

--- a/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
@@ -67,14 +67,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
         it "should return the ref" do
           resource[:revision] = '2634'
           provider.expects(:bzr).with('revision-info', '2634').returns("2634 menesis@pov.lt-20100309191856-4wmfqzc803fj300x\n")
-          provider.revision.should == resource.value(:revision)
+          expect(provider.revision).to eq(resource.value(:revision))
         end
       end
       context "when its revid is different than the current revid" do
         it "should return the current revid" do
           resource[:revision] = '2636'
           provider.expects(:bzr).with('revision-info', resource.value(:revision)).returns("2635 foo\n")
-          provider.revision.should == @current_revid
+          expect(provider.revision).to eq(@current_revid)
         end
       end
     end
@@ -84,14 +84,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
         it "should return it" do
           resource[:revision] = 'menesis@pov.lt-20100309191856-4wmfqzc803fj300x'
           provider.expects(:bzr).with('revision-info', resource.value(:revision)).returns("1234 #{resource.value(:revision)}\n")
-          provider.revision.should == resource.value(:revision)
+          expect(provider.revision).to eq(resource.value(:revision))
         end
       end
       context "when it is not the same as the current revid" do
         it "should return the current revid" do
           resource[:revision] = 'menesis@pov.lt-20100309191856-4wmfqzc803fj300y'
           provider.expects(:bzr).with('revision-info', resource.value(:revision)).returns("2636 foo\n")
-          provider.revision.should == @current_revid
+          expect(provider.revision).to eq(@current_revid)
         end
       end
 

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -86,7 +86,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
       end
       it "should read CVS/Tag" do
         File.expects(:read).with(@tag_file).returns("T#{@tag}")
-        provider.revision.should == @tag
+        expect(provider.revision).to eq(@tag)
       end
     end
 
@@ -95,7 +95,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
         File.expects(:exist?).with(@tag_file).returns(false)
       end
       it "assumes HEAD" do
-        provider.revision.should == 'HEAD'
+        expect(provider.revision).to eq('HEAD')
       end
     end
   end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -134,7 +134,7 @@ branches
         it "should raise an exception" do
           provider.expects(:path_exists?).returns(true)
           provider.expects(:path_empty?).returns(false)
-          proc { provider.create }.should raise_error(Puppet::Error)
+          expect { provider.create }.to raise_error(Puppet::Error)
         end
       end
     end
@@ -204,7 +204,7 @@ branches
         provider.expects(:path_exists?).returns(true)
         provider.expects(:path_empty?).returns(false)
         provider.expects(:working_copy_exists?).returns(false)
-        proc { provider.create }.should raise_error(Puppet::Error)
+        expect { provider.create }.to raise_error(Puppet::Error)
       end
     end
   end
@@ -233,14 +233,14 @@ branches
     context "when its SHA is not different than the current SHA" do
       it "should return the ref" do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
-        provider.revision.should == resource.value(:revision)
+        expect(provider.revision).to eq(resource.value(:revision))
       end
     end
 
     context "when its SHA is different than the current SHA" do
       it "should return the current SHA" do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('othersha')
-        provider.revision.should == resource.value(:revision)
+        expect(provider.revision).to eq(resource.value(:revision))
       end
     end
 
@@ -248,7 +248,7 @@ branches
       it "should return the revision" do
         provider.stubs(:git).with('branch', '-a').returns("  remotes/origin/#{resource.value(:revision)}")
         provider.expects(:git).with('rev-parse', "origin/#{resource.value(:revision)}").returns("newsha")
-        provider.revision.should == resource.value(:revision)
+        expect(provider.revision).to eq(resource.value(:revision))
       end
     end
 
@@ -267,7 +267,7 @@ branches
         provider.expects(:git).with('config', 'remote.origin.url').returns('old')
         provider.expects(:git).with('config', 'remote.origin.url', 'git://git@foo.com/bar.git')
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
-        provider.revision.should == resource.value(:revision)
+        expect(provider.revision).to eq(resource.value(:revision))
       end
     end
   end
@@ -329,13 +329,13 @@ branches
       context "when it's listed in 'git branch -a'" do
         it "should return true" do
           resource[:revision] = 'feature/foo'
-          provider.should be_local_branch_revision
+          expect(provider).to be_local_branch_revision
         end
       end
       context "when it's not listed in 'git branch -a'" do
         it "should return false" do
           resource[:revision] = 'feature/notexist'
-          provider.should_not be_local_branch_revision
+          expect(provider).not_to be_local_branch_revision
         end
       end
     end
@@ -343,13 +343,13 @@ branches
       context "when it's listed in 'git branch -a' with an 'origin/' prefix" do
         it "should return true" do
           resource[:revision] = 'only/remote'
-          provider.should be_remote_branch_revision
+          expect(provider).to be_remote_branch_revision
         end
       end
       context "when it's not listed in 'git branch -a' with an 'origin/' prefix" do
         it "should return false" do
           resource[:revision] = 'only/local'
-          provider.should_not be_remote_branch_revision
+          expect(provider).not_to be_remote_branch_revision
         end
       end
     end
@@ -360,14 +360,14 @@ branches
       it do
         provider.expects(:revision).returns('testrev')
         provider.expects(:latest_revision).returns('testrev')
-        provider.latest?.should be_true
+        expect(provider.latest?).to be_truthy
       end
     end
     context 'when false' do
       it do
         provider.expects(:revision).returns('master')
         provider.expects(:latest_revision).returns('testrev')
-        provider.latest?.should be_false
+        expect(provider.latest?).to be_falsey
       end
     end
   end

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -88,14 +88,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
       context "when its SHA is not different than the current SHA" do
         it "should return the ref" do
           resource[:revision] = '0.6'
-          provider.revision.should == '0.6'
+          expect(provider.revision).to eq('0.6')
         end
       end
 
       context "when its SHA is different than the current SHA" do
         it "should return the current SHA" do
           resource[:revision] = '0.5.3'
-          provider.revision.should == '34e6012c783a'
+          expect(provider.revision).to eq('34e6012c783a')
         end
       end
     end
@@ -108,7 +108,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
         it "should return it" do
           resource[:revision] = '34e6012c783a'
           provider.expects(:hg).with('tags').returns(fixture(:hg_tags))
-          provider.revision.should == resource.value(:revision)
+          expect(provider.revision).to eq(resource.value(:revision))
         end
       end
 
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
         it "should return the current SHA" do
           resource[:revision] = 'not-the-same'
           provider.expects(:hg).with('tags').returns(fixture(:hg_tags))
-          provider.revision.should == '34e6012c783a'
+          expect(provider.revision).to eq('34e6012c783a')
         end
       end
     end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     end
     it "should use 'svn info'" do
       expects_chdir
-      provider.revision.should == '4' # From 'Revision', not 'Last Changed Rev'
+      expect(provider.revision).to eq('4') # From 'Revision', not 'Last Changed Rev'
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 2.3.7 with the following command:
    transpec
- 22 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 19 conversions
  from: obj.should
    to: expect(obj).to
- 15 conversions
  from: == expected
    to: eq(expected)
- 5 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }
- 2 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 2 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 2 conversions
  from: proc { }.should
    to: expect { }.to
- 1 conversion
  from: be_false
    to: be_falsey
- 1 conversion
  from: be_true
    to: be_truthy

For more details: https://github.com/yujinakayama/transpec#supported-conversions
