### PR TITLE
(FM-1951) Ensure Git is installable on EL 5 platforms

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   end
 end
 
+
 RSpec.configure do |c|
   # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
@@ -35,9 +36,21 @@ RSpec.configure do |c|
       copy_module_to(host, :source => proj_root, :module_name => 'vcsrepo')
       case fact_on(host, 'osfamily')
       when 'RedHat'
+        if fact_on(host, 'operatingsystemmajrelease') == '5'
+          will_install_git = on(host, 'which git', :acceptable_exit_codes => [0,1]).exit_code == 1
+
+          if will_install_git
+            on host, puppet('module install stahnma-epel')
+            apply_manifest_on( host, 'include epel' )
+          end
+
+        end
+
         install_package(host, 'git')
+
       when 'Debian'
         install_package(host, 'git-core')
+
       else
         if !check_for_package(host, 'git')
           puts "Git package is required for this module"


### PR DESCRIPTION
Git is not installed on EL 5, but it is not in the repos either.
With this patch, if we are going to install git on an EL 5 platform we
first ensure epel is installed(FM-1951) Ensure Git is installable on
EL 5 platforms
