### PR TITLE
Add submodules feature to git provider

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -141,6 +141,15 @@ To keep the repository at the latest revision (**WARNING:** this will always ove
       revision => 'master',
     }
 
+To clone the repository but skip initialiazing submodules,
+
+    vcsrepo { "/path/to/repo":
+      ensure     => latest,
+      provider   => git,
+      source     => 'git://example.com/repo.git',
+      submodules => false,
+    }
+
 #####Sources that use SSH
 
 When your source uses SSH, such as 'username@server:…', you can manage your SSH keys with Puppet using the [require](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) metaparameter in `vcsrepo` to ensure they are present.
@@ -479,6 +488,7 @@ The vcsrepo module is slightly unusual in that it is simply a type and providers
 * `ssh_identity` - The provider supports a configurable SSH identity file. (Available with `git` and `hg`.)
 * `user` - The provider can run as a different user. (Available with `git`, `hg` and `cvs`.)
 * `p4config` - The provider support setting the P4CONFIG environment. (Available with `p4`.)
+* `submodules` - The provider supports repository submodules which can be optionally initialized. (Available with `git`.)
 
 ####Parameters
 
@@ -507,9 +517,9 @@ The vcsrepo module is slightly unusual in that it is simply a type and providers
 ####Features and Parameters by Provider
 
 #####`git`
-**Features**: `bare_repositories`, `depth`, `multiple_remotes`, `reference_tracking`, `ssh_identity`, `user`
+**Features**: `bare_repositories`, `depth`, `multiple_remotes`, `reference_tracking`, `ssh_identity`, `user`, `submodules`
 
-**Parameters**: `depth`, `ensure`, `excludes`, `force`, `group`, `identity`, `owner`, `path`, `provider`, `remote`, `revision`, `source`, `user`
+**Parameters**: `depth`, `ensure`, `excludes`, `force`, `group`, `identity`, `owner`, `path`, `provider`, `remote`, `revision`, `source`, `user`, `submodules`
 
 #####`bzr`
 **Features**: `reference_tracking`

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   commands :git => 'git'
 
-  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth
+  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth, :submodules
 
   def create
     if @resource.value(:revision) and @resource.value(:ensure) == :bare
@@ -18,7 +18,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
       if @resource.value(:revision)
         checkout
       end
-      if @resource.value(:ensure) != :bare
+      if @resource.value(:ensure) != :bare && @resource.value(:submodules) == :true
         update_submodules
       end
     end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -43,6 +43,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :p4config,
           "The provider understands Perforce Configuration"
 
+  feature :submodules,
+          "The repository contains submodules which can be optionally initialized"
+
   ensurable do
     attr_accessor :latest
 
@@ -213,6 +216,12 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :p4config, :required_features => [:p4config] do
     desc "The Perforce P4CONFIG environment."
+  end
+
+  newparam :submodules, :required_features => [:submodules] do
+    desc "Initialize and update each submodule in the repository."
+    newvalues(:true, :false)
+    defaultto true
   end
 
   autorequire(:package) do


### PR DESCRIPTION
This PR adds the ability to skip initializing git submodules when cloning a repository (i.e. `git submodule update --init --recursive`)
The default behaviour is still the same.
