### PR TITLE
Add support for 'conflict' parameter to populate svn --accept arg

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
            :svnadmin => 'svnadmin',
            :svnlook  => 'svnlook'
 
-  has_features :filesystem_types, :reference_tracking, :basic_auth, :configuration
+  has_features :filesystem_types, :reference_tracking, :basic_auth, :configuration, :conflict
 
   def create
     if !@resource.value(:source)
@@ -92,6 +92,11 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
            else
              buildargs.push('update', '-r', desired)
            end
+
+    if @resource.value(:conflict)
+      args.push('--accept', @resource.value(:conflict))
+    end
+
     at_path do
       svn(*args)
     end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -46,6 +46,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :submodules,
           "The repository contains submodules which can be optionally initialized"
 
+  feature :conflict,
+          "The provider supports automatic conflict resolution"
+
   ensurable do
     attr_accessor :latest
 
@@ -212,6 +215,10 @@ Puppet::Type.newtype(:vcsrepo) do
     desc "Initialize and update each submodule in the repository."
     newvalues(:true, :false)
     defaultto true
+  end
+
+  newparam :conflict do
+    desc "The action to take if conflicts exist between repository and working copy"
   end
 
   autorequire(:package) do

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -83,10 +83,22 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     before do
       @revision = '30'
     end
-    it "should use 'svn update'" do
-      expects_chdir
-      provider.expects(:svn).with('--non-interactive', 'update', '-r', @revision)
-      provider.revision = @revision
+    context 'with conflict' do
+      it "should use 'svn update'" do
+        resource[:conflict] = 'theirs-full'
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'update',
+                                    '-r', @revision,
+                                    '--accept', resource.value(:conflict))
+        provider.revision = @revision
+      end
+    end
+    context 'without conflict' do
+      it "should use 'svn update'" do
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'update', '-r', @revision)
+        provider.revision = @revision
+      end
     end
   end
 
@@ -94,11 +106,24 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     before do
       @revision = '30'
     end
-    it "should use 'svn switch'" do
-      resource[:source] = 'an-unimportant-value'
-      expects_chdir
-      provider.expects(:svn).with('--non-interactive', 'switch', '-r', @revision, 'an-unimportant-value')
-      provider.revision = @revision
+    context 'with conflict' do
+      it "should use 'svn switch'" do
+        resource[:source] = 'an-unimportant-value'
+        resource[:conflict] = 'theirs-full'
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'switch',
+                                    '-r', @revision, 'an-unimportant-value',
+                                    '--accept', resource.value(:conflict))
+        provider.revision = @revision
+      end
+    end
+    context 'without conflict' do
+      it "should use 'svn switch'" do
+        resource[:source] = 'an-unimportant-value'
+        expects_chdir
+        provider.expects(:svn).with('--non-interactive', 'switch', '-r', @revision, 'an-unimportant-value')
+        provider.revision = @revision
+      end
     end
   end
 


### PR DESCRIPTION
Allow setting the subversion behaviour on encountering conflicts to something other than the default (postpone), which is undesirable in many cases.

https://tickets.puppetlabs.com/browse/MODULES-1551