### PR TITLE
Shallow clone with one commit that corresponds to arbitrary tag from arbitrary branch

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   commands :git => 'git'
 
-  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth, :submodules
+  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth, :branch, :submodules
 
   def create
     if @resource.value(:revision) and @resource.value(:ensure) == :bare
@@ -179,6 +179,9 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     args = ['clone']
     if @resource.value(:depth) and @resource.value(:depth).to_i > 0
       args.push('--depth', @resource.value(:depth).to_s)
+    end
+    if @resource.value(:branch)
+      args.push('--branch', @resource.value(:branch).to_s)
     end
     if @resource.value(:ensure) == :bare
       args << '--bare'

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -40,6 +40,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :depth,
           "The provider can do shallow clones"
 
+  feature :branch,
+          "The name of the branch"
+
   feature :p4config,
           "The provider understands Perforce Configuration"
 
@@ -202,6 +205,10 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :depth, :required_features => [:depth] do
     desc "The value to be used to do a shallow clone."
+  end
+
+  newparam :branch, :required_features => [:branch] do
+    desc "The name of the branch to clone."
   end
 
   newparam :p4config, :required_features => [:p4config] do


### PR DESCRIPTION
I try to clone a single revision from arbitrary branch. Something like:

    git clone --depth 1 --branch v2.6.1 https://github.com/symfony/symfony-standard.git

Here: v2.6.1 is a tag. And I want to clone only one revision: the one that corresponds to this tag.

The following configuration:

    vcsrepo { '/home/vagrant/p01':
      provider => 'git',
      source   => 'https://github.com/symfony/symfony-standard.git',
      user     => 'vagrant',
      revision => 'v2.6.1',
      depth    => 1
    }

fails producing the error:

    Error: Execution of '/bin/su vagrant -c git checkout --force v2.6.1' returned 1:
    error: pathspec 'v2.6.1' did not    match any file(s) known to git.

I think `branch` parameter is necessary.

I have already made one PR: #212

This time I removed superfluous parameter `--single-branch`.

What do you think @sodabrew? 


