### PR TITLE
Implemented multiple remotes feature for git provider.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -154,6 +154,20 @@ To clone the repository but skip initialiazing submodules,
       submodules => false,
     }
 
+##### Using multiple remotes with a repository
+Instead of specifying a single string in the 'source' property, you can specify a hash with multiple name => URL mappings,
+
+    vcsrepo { "/path/to/repo":
+      ensure   => present,
+      provider => git,
+      source   => {
+        "origin"       => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git", 
+        "other_remote" => "https://github.com/other_user/puppetlabs-vcsrepo.git"
+      },
+    }
+
+It is important to note that you must specify a mapping for the remote that is specified in the 'remote' property - this is set to 'origin' by default.
+
 #####Sources that use SSH
 
 When your source uses SSH, such as 'username@server:…', you can manage your SSH keys with Puppet using the [require](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) metaparameter in `vcsrepo` to ensure they are present.

--- a/spec/acceptance/modules_753_spec.rb
+++ b/spec/acceptance/modules_753_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper_acceptance'
+
+tmpdir = default.tmpdir('vcsrepo')
+
+describe 'clones a remote repo' do
+  before(:all) do
+    my_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    shell("mkdir -p #{tmpdir}") # win test
+  end
+
+  after(:all) do
+    shell("rm -rf #{tmpdir}/vcsrepo")
+  end
+
+  context 'clone with single remote' do
+    it 'clones from default remote' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/vcsrepo":
+          ensure   => present,
+          provider => git,
+          source   => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git",
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+
+    end
+
+    it "git config output should contain the remote" do
+      shell("/usr/bin/git config -l -f #{tmpdir}/vcsrepo/.git/config") do |r|
+        expect(r.stdout).to match(/remote.origin.url=https:\/\/github.com\/puppetlabs\/puppetlabs-vcsrepo.git/)
+      end
+    end
+
+    after(:all) do
+      shell("rm -rf #{tmpdir}/vcsrepo")
+    end
+
+  end
+
+  context 'clone with multiple remotes' do
+    it 'clones from default remote and adds 2 remotes to config file' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/vcsrepo":
+          ensure   => present,
+          provider => git,
+          source   => {"origin" => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git", "test1" => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"},
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+
+    end
+
+    it "git config output should contain the remotes" do
+      shell("/usr/bin/git config -l -f #{tmpdir}/vcsrepo/.git/config") do |r|
+        expect(r.stdout).to match(/remote.origin.url=https:\/\/github.com\/puppetlabs\/puppetlabs-vcsrepo.git/)
+        expect(r.stdout).to match(/remote.test1.url=https:\/\/github.com\/puppetlabs\/puppetlabs-vcsrepo.git/)
+      end
+    end
+
+    after(:all) do
+      shell("rm -rf #{tmpdir}/vcsrepo")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR allows multiple remotes to be used by specifying a hash of name => URL mappings in the source property, instead of just a single URL string.