### PR TITLE
sanity check for presence of Puppet::Util::Execution.execute

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -430,7 +430,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
         return ret
       end
     elsif @resource.value(:user) and @resource.value(:user) != Facter['id'].value
-      Puppet::Util::Execution.execute("git #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true)
+      if Puppet::Util::Execution.respond_to?('execute')
+        Puppet::Util::Execution.execute("git #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true)
+      else
+        Puppet::Util.execute("git #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true)
+      end
     else
       git(*args)
     end


### PR DESCRIPTION
fixes a bug when cloning a private git repository using puppet 2.7 and a specific user fails with:
```
change from absent to latest failed: Could not set 'latest on ensure: undefined method `execute' for Puppet::Util::Execution:Module
```