### PR TITLE
Fix remote hash ordering for unit tests

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -142,7 +142,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     # we loop around the hash. Otherwise, we assume single url specified
     # in source property
     if @resource.value(:source).is_a?(Hash)
-      @resource.value(:source).each do |remote_name, remote_url|
+      @resource.value(:source).keys.sort.each do |remote_name|
+        remote_url = @resource.value(:source)[remote_name]
         at_path { do_update |= update_remote_url(remote_name, remote_url) }
       end
     else

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -263,7 +263,7 @@ branches
     context "when multiple sources are modified" do
       it "should update the urls" do
         resource[:source] = {"origin" => "git://git@foo.com/bar.git", "new_remote" => "git://git@foo.com/baz.git"}
-        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.origin.url=git://git@foo.com/foo.git\n", "remote.origin.url=git://git@foo.com/bar.git\n")
+        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.origin.url=git://git@foo.com/bar.git\n", "remote.origin.url=git://git@foo.com/foo.git\n")
         provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
         provider.expects(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
         provider.expects(:git).with('remote','update')


### PR DESCRIPTION
Without this commit, the unit tests for the git provider changing
multiple remotes mocks the remotes in a particular order. While in
practice it doesn't matter which remote the update_remotes method
updates first, the unit tests must be able to mock them in the correct
order. For ruby 1.8.7, a Hash will not necessarily produce key value
pairs in the same order on each run, which causes intermittent failures
in the unit tests. This change sorts the :source property values before
trying to update them, and updates the unit tests to expect the values
in alphabetical order.