### PR TITLE
Clean up puppet lint warnings

### DIFF
--- a/examples/p4/create_client.pp
+++ b/examples/p4/create_client.pp
@@ -1,4 +1,4 @@
 vcsrepo { '/tmp/vcstest/p4_client_root':
-  ensure    => present,
-  provider  => 'p4',
+  ensure   => present,
+  provider => 'p4',
 }

--- a/examples/p4/delete_client.pp
+++ b/examples/p4/delete_client.pp
@@ -1,4 +1,4 @@
 vcsrepo { '/tmp/vcstest/p4_client_root':
-  ensure    => absent,
-  provider  => 'p4',
+  ensure   => absent,
+  provider => 'p4',
 }

--- a/examples/p4/latest_client.pp
+++ b/examples/p4/latest_client.pp
@@ -1,5 +1,5 @@
 vcsrepo { '/tmp/vcstest/p4_client_root':
-  ensure    => latest,
-  provider  => 'p4',
-  source    => '//depot/...',
+  ensure   => latest,
+  provider => 'p4',
+  source   => '//depot/...',
 }

--- a/examples/p4/sync_client.pp
+++ b/examples/p4/sync_client.pp
@@ -1,6 +1,6 @@
 vcsrepo { '/tmp/vcstest/p4_client_root':
-  ensure    => present,
-  provider  => 'p4',
-  source    => '//depot/...',
-  revision  => '30',
+  ensure   => present,
+  provider => 'p4',
+  source   => '//depot/...',
+  revision => '30',
 }


### PR DESCRIPTION
There were puppet lint warnings due to indentation in several examples.
This commit cleans up the warnings.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>