### PR TITLE
fix for force => false not being honoured

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -199,11 +199,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   # @!visibility private
   def check_force
-    if path_exists? and not path_empty?
-      if @resource.value(:force)
+    if File.exists?(@resource.value(:path))
+      if @resource.value(:force) == :true
         notice "Removing %s to replace with vcsrepo." % @resource.value(:path)
         destroy
-      else
+      elsif not (path_exists? and path_empty?)
         raise Puppet::Error, "Could not create repository (non-repository at path)"
       end
     end
@@ -360,7 +360,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   # @return [String] Returns the output of get_revision
   def latest_revision
     #TODO Why is create called here anyway?
-    create if @resource.value(:force) && working_copy_exists?
+    create if (@resource.value(:force) == :true && working_copy_exists?)
     create if !working_copy_exists?
 
     if branch = on_branch?

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:vcsrepo) do
     end
 
     newvalue :latest, :required_features => [:reference_tracking] do
-      if provider.exists? && !@resource.value(:force)
+      if provider.exists? && @resource.value(:force) != :true
         if provider.respond_to?(:update_references)
           provider.update_references
         end


### PR DESCRIPTION
There is a nasty bug in this module since 1.0.0 where setting force => false is not honoured for git.

Existing nasty behaviour:
```
force => undef  # will not recreate
force => false  # will always recreate
force => true   # will always recreate
```

New/proper/intended behaviour:
```
force => undef  # will not recreate
force => false  # will not recreate
force => true   # will always recreate
```

Recreating when false is really nasty because it will delete any untracked files in the target directory.

Tested with puppet --version 3.7.5 and ruby --version ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]