### PR TITLE
(MODULES-821) Don't use /tmp

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -418,7 +418,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   # @!visibility private
   def git_with_identity(*args)
     if @resource.value(:identity)
-      Tempfile.open('git-helper') do |f|
+      Tempfile.open('git-helper', Puppet[:statedir]) do |f|
         f.puts '#!/bin/sh'
         f.puts "exec ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no -oConnectTimeout=120 -i #{@resource.value(:identity)} $*"
         f.close


### PR DESCRIPTION
Very often /tmp is mounted noexec for security reasons related to it
being writable by all users. This stopped vcsrepo's git provider from
working.

This pull request uses puppet's statedir as it is not writable by all
users and is a good candidate for transient state like the git
provider's identity script for the $GIT_SSH command.

An alternative in the future that wouldn't require a temporary file is
to set $GIT_SSH_COMMAND instead of $GIT_SSH, except this was added in
git 2.3 and is too new to depend on.