### PR TITLE
Explitly unset SSH_AUTH_SOCK; it is preferred to the -i flag

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -425,6 +425,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     if @resource.value(:identity)
       Tempfile.open('git-helper', Puppet[:statedir]) do |f|
         f.puts '#!/bin/sh'
+        f.puts 'export SSH_AUTH_SOCKET='
         f.puts "exec ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no -oConnectTimeout=120 -i #{@resource.value(:identity)} $*"
         f.close
 


### PR DESCRIPTION
Even if the -i flag is explicitly passed via the command line, openssh
ignores the identity file if an socket exists to an SSH authentication
agent.  In cases where puppet has been configured to use an explicit
identity file, altering behavior based on the calling environment of
puppet violates the principle of least surprise, and can lead to
inconsistent deployments.

Work around this odd corner case of ssh by explicitly unsetting
SSH_AUTH_SOCK inside the ssh wrapper.