### PR TITLE
MODULES-1800 - fix case where ensure => latest and no revision specified

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -45,7 +45,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   #
   # @return [String] Returns the target sha/tag/branch
   def latest
-    @resource.value(:revision)
+    if not @resource.value(:revision) and branch = on_branch?
+      return branch
+    else
+      return @resource.value(:revision)
+    end
   end
 
   # Get the current revision of the repo (tag/branch/sha)
@@ -281,7 +285,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   # handle upstream branch changes
   # @!visibility private
   def checkout(revision = @resource.value(:revision))
-    if !local_branch_revision? && remote_branch_revision?
+    if !local_branch_revision?(revision) && remote_branch_revision?(revision)
       #non-locally existant branches (perhaps switching to a branch that has never been checked out)
       at_path { git_with_identity('checkout', '--force', '-b', revision, '--track', "#{@resource.value(:remote)}/#{revision}") }
     else

--- a/spec/acceptance/modules_1800_spec.rb
+++ b/spec/acceptance/modules_1800_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper_acceptance'
+
+tmpdir = default.tmpdir('vcsrepo')
+
+describe 'clones a remote repo' do
+  before(:all) do
+    my_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    shell("mkdir -p #{tmpdir}") # win test
+  end
+
+  after(:all) do
+    shell("rm -rf #{tmpdir}/vcsrepo")
+  end
+
+  context 'ensure latest with no revision' do
+    it 'clones from default remote' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/vcsrepo":
+          ensure   => present,
+          provider => git,
+          source   => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git",
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      shell("cd #{tmpdir}/vcsrepo; /usr/bin/git reset --hard HEAD~2")
+    end
+
+    it 'updates' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/vcsrepo":
+          ensure   => latest,
+          provider => git,
+          source   => "https://github.com/puppetlabs/puppetlabs-vcsrepo.git",
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+  end
+end


### PR DESCRIPTION
This would explode when revision was unspecified when you were on a
branch. Use the branch you're currently on when updating.