### PR TITLE
Autorequire Package['mercurial']

### DIFF
--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -229,6 +229,6 @@ Puppet::Type.newtype(:vcsrepo) do
   end
 
   autorequire(:package) do
-    ['git', 'git-core']
+    ['git', 'git-core', 'mercurial']
   end
 end


### PR DESCRIPTION
Along the lines of 2b190756260346931b8f9a0dda8afc0c815710d6, if the
Mercurial package is being managed, it stands to reason that the Mercurial
package should be installed before trying to potentially manage Mercurial
repositories using vcsrepo resources.

This commit adds an autorequire to the vcsrepo type that reflects the
above premise.