### PR TITLE
Adding svn provider support for versioning of individual files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -519,7 +519,94 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-#### Use a specific Subversion configuration directory
+####Checking out only specific paths
+
+You can check out only specific paths in a particular repository by providing their relative paths to the `include` parameter, like so:
+
+~~~
+vcsrepo { '/path/to/repo':
+  ensure   => present,
+  provider => svn,
+  source   => 'http://svnrepo/hello/trunk',
+  includes => [
+    'root-file.txt',
+    'checkout-folder',
+    'file/this-file.txt',
+    'folder/this-folder/',
+  ]
+}
+~~~
+
+This will create files `/path/to/repo/file-at-root-path.txt` and `/path/to/repo/file/nested/within/repo.jmx`, with folders `/path/to/repo/some-folder` and `/path/to/repo/nested/folder/to/checkout` completely recreating their corresponding working tree path.
+
+When specified, the `depth` parameter will also be applied to the `includes` -- the root directory will be checked out using an `empty` depth, and the `includes` you specify will be checked out using the `depth` you provide.
+
+To illustrate this point, using the above snippet (with the specified `includes`) and a remote repository layout like this:
+
+~~~
+.
+├── checkout-folder
+│   ├── file1
+│   └── nested-1
+│       ├── nested-2
+│       │   └── nested-file-2
+│       └── nested-file-1
+├── file
+│   ├── NOT-this-file.txt
+│   └── this-file.txt
+├── folder
+│   ├── never-checked-out
+│   └── this-folder
+│       ├── deep-nested-1
+│       │   ├── deep-nested-2
+│       │   │   └── deep-nested-file-2
+│       │   └── deep-nested-file-1
+│       └── this-file.txt
+├── NOT-this-file.txt
+├── NOT-this-folder
+│   ├── NOT-this-file.txt
+│   └── NOT-this-one-either.txt
+└── root-file.txt
+~~~
+
+With no `depth` given, your local folder `/path/to/repo` will look like this:
+
+~~~
+.
+├── checkout-folder
+│   ├── file1
+│   └── nested-1
+│       ├── nested-2
+│       │   └── nested-file-2
+│       └── nested-file-1
+├── file
+│   └── this-file.txt
+├── folder
+│   └── this-folder
+│       ├── deep-nested-1
+│       │   ├── deep-nested-2
+│       │   │   └── deep-nested-file-2
+│       │   └── deep-nested-file-1
+│       └── this-file.txt
+└── root-file.txt
+~~~
+
+And with a `depth` of `files` will look like this:
+
+~~~
+.
+├── checkout-folder
+│   └── file1
+├── file
+│   └── this-file.txt
+├── folder
+│   └── this-folder
+│       └── this-file.txt
+└── root-file.txt
+~~~
+
+
+####Use a specific Subversion configuration directory 
 
 Use the `configuration` parameter to designate the directory that contains your Subversion configuration files (typically, '/path/to/.subversion'):
 

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -7,7 +7,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     environment({ 'HOME' => ENV['HOME'] })
   end
 
-  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth, :branch, :submodules
+  has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes,
+    :user, :depth, :branch, :submodules
 
   def create
     check_force

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :conflict,
           "The provider supports automatic conflict resolution"
 
+  feature :include_paths,
+          "The provider supports checking out only specific paths"
+
   ensurable do
     attr_accessor :latest
 
@@ -195,7 +198,18 @@ Puppet::Type.newtype(:vcsrepo) do
   end
 
   newparam :excludes do
-    desc "Files to be excluded from the repository"
+    desc "Local paths which shouldn't be tracked by the repository"
+  end
+
+  newproperty :includes, :required_features => [:include_paths], :array_matching => :all do
+    desc "Paths to be included from the repository"
+    def insync?(is)
+      if is.is_a?(Array) and @should.is_a?(Array)
+        is.sort == @should.sort
+      else
+        is == @should
+      end
+    end
   end
 
   newparam :force do

--- a/spec/acceptance/svn_paths_spec.rb
+++ b/spec/acceptance/svn_paths_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper_acceptance'
+
+tmpdir = default.tmpdir('vcsrepo')
+
+describe 'subversion :includes tests' do
+
+  before(:all) do
+    shell("mkdir -p #{tmpdir}") # win test
+  end
+
+  after(:all) do
+    shell("rm -rf #{tmpdir}/svnrepo")
+  end
+
+  context "include paths" do
+    it "can checkout specific paths from svn" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        includes => ['difftools/README', 'obsolete-notes',],
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1000000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/difftools") do
+      it { should be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/README") do
+      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes") do
+      it { should be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes/draft-korn-vcdiff-01.txt") do
+      its(:md5sum) { should eq '37019f808e1af64864853a67526cfe19' }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes/vcdiff-karlnotes") do
+      its(:md5sum) { should eq '26e23ff6a156de14aebd1099e23ac2d8' }
+    end
+    describe file("#{tmpdir}/svnrepo/guis") do
+      it { should_not exist }
+    end
+  end
+
+  context "add include paths" do
+    it "can add paths to includes" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        includes => ['difftools/README', 'obsolete-notes', 'guis/pics/README', 'difftools/pics/README'],
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1000000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+      its(:md5sum) { should eq '62bdc9180684042fe764d89c9beda40f' }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+      its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
+    end
+  end
+
+  context "remove include paths" do
+    it "can remove paths (and empty parent directories) from includes" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        includes => ['difftools/README', 'obsolete-notes',],
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1000000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/guis") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/README") do
+      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+    end
+  end
+
+  context "changing revisions" do
+    it "can change revisions" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        includes => ['difftools/README', 'obsolete-notes',],
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1700000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe command("svn info #{tmpdir}/svnrepo") do
+      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
+    end
+    describe command("svn info #{tmpdir}/svnrepo/difftools/README") do
+      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
+    end
+  end
+
+end

--- a/spec/acceptance/svn_spec.rb
+++ b/spec/acceptance/svn_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper_acceptance'
+
+tmpdir = default.tmpdir('vcsrepo')
+
+describe 'subversion tests' do
+  before(:each) do
+    shell("mkdir -p #{tmpdir}") # win test
+  end
+
+  context "plain checkout" do
+    it "can checkout svn" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        source   => "http://svn.apache.org/repos/asf/subversion/svn-logos/",
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+    end
+
+    describe file("#{tmpdir}/svnrepo/.svn") do
+      it { is_expected.to be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/images/tyrus-svn2.png") do
+      its(:md5sum) { should eq '6b20cbc4a793913190d1548faad1ae80' }
+    end
+
+    after(:all) do
+      shell("rm -rf #{tmpdir}/svnrepo")
+    end
+
+  end
+
+  context "handles revisions" do
+    it "can checkout a specific revision of svn" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1000000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+    end
+
+    describe file("#{tmpdir}/svnrepo/.svn") do
+      it { is_expected.to be_directory }
+    end
+    describe command("svn info #{tmpdir}/svnrepo") do
+      its(:stdout) { should match( /.*Revision: 1000000.*/ ) }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/README") do
+      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+    end
+
+  end
+
+  context "handles revisions" do
+    it "can switch revisions" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        revision => 1700000,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+    end
+
+    describe file("#{tmpdir}/svnrepo/.svn") do
+      it { is_expected.to be_directory }
+    end
+    describe command("svn info #{tmpdir}/svnrepo") do
+      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
+    end
+
+    after(:all) do
+      shell("rm -rf #{tmpdir}/svnrepo")
+    end
+
+  end
+
+  context "switching sources" do
+    it "can checkout tag=1.9.0" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.0/",
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+    describe file("#{tmpdir}/svnrepo/.svn") do
+      it { is_expected.to be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/STATUS") do
+      its(:md5sum) { should eq '286708a30aea43d78bc2b11f3ac57fff' }
+    end
+  end
+
+  context "switching sources" do
+    it "can switch to tag=1.9.4" do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/svnrepo":
+        ensure   => present,
+        provider => svn,
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.4/",
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/.svn") do
+      it { is_expected.to be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/STATUS") do
+      its(:md5sum) { should eq '7f072a1c0e2ba37ca058f65e554de95e' }
+    end
+
+  end
+
+end
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,13 +29,19 @@ RSpec.configure do |c|
         end
 
         install_package(host, 'git')
+        install_package(host, 'subversion')
 
       when 'Debian'
         install_package(host, 'git-core')
+        install_package(host, 'subversion')
 
       else
         if !check_for_package(host, 'git')
           puts "Git package is required for this module"
+          exit
+        end
+        if !check_for_package(host, 'subversion')
+          puts "Subversion package is required for this module"
           exit
         end
       end


### PR DESCRIPTION
I extended the SVN provider to include some particular functionality I needed, but I'm not sure if it fits with the "goal" of the module. If it does, I'll add tests and make it more robust; otherwise I'll fork it off into my own module.

Two features have been added to the provider.

1. Export support
    Added `:export` parameter/feature to type/provider -- accepts `:true` or `:false`
Provider runs `svn export` instead of `svn checkout` if `:export` is `true`, which creates an non-versioned copy of the working tree in `path`. Of course, since it is non-versioned, there is no way of tracking revision through `svn`, so each subsequent puppet run requires `:force` to be `true`.

2. Cherry-picking individual files from the repo
Added `:files` parameter/feature to type/provider -- accepts array (Should probably be renamed to `:paths`)
Implements functionality of [subversion sparse directories](http://svnbook.red-bean.com/en/1.7/svn.advanced.sparsedirs.html). Only useful when using a non-full `depth`. It calls `svn update` on the paths that are passed through to it.
In other words, if you want to check out only certain parts of the repo to the local working tree, you could, for example, do:
```puppet
vcsrepo { '/some/local/directory':
  ensure => present,
  provider => svn,
  depth => 'immediates',
  source => 'http://svn.example.com/',
  files => ['/some/path', '/some/file.txt', '/some/otherfile.txt']
}
```