### PR TITLE
fix branch existence determintaion functionality

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -319,7 +319,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def remote_branch_revision?(revision = @resource.value(:revision))
     # git < 1.6 returns '#{@resource.value(:remote)}/#{revision}'
     # git 1.6+ returns 'remotes/#{@resource.value(:remote)}/#{revision}'
-    branch = at_path { branches.grep /(remotes\/)?#{@resource.value(:remote)}\/#{revision}/ }
+    branch = at_path { branches.grep /(remotes\/)?#{@resource.value(:remote)}\/#{revision}$/ }
     branch unless branch.empty?
   end
 


### PR DESCRIPTION
this will stop failing in case there is a tag which is a substring of an existing branch name.
for example if there is a tag 'release' and a branch 'release/integration' current code will match 'release/integration' with pattern 'release' and decide that a branch checkout is needed. but release branch does not exist so it will fail.
this simple fix resolves the issue.