### PR TITLE
Add mirror option for git cloning

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -94,6 +94,16 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+If you want to clone your repository as bare or mirror, you can set `ensure` to 'bare' or 'mirror':
+
+~~~
+vcsrepo { '/path/to/repo':
+  ensure   => mirror,
+  provider => git,
+  source   => 'git://example.com/repo.git',
+}
+~~~
+
 By default, `vcsrepo` will use the HEAD of the source repository's master branch. To use another branch or a specific commit, set `revision` to either a branch name or a commit SHA or tag.
 
 Branch name:

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -69,6 +69,8 @@ Puppet::Type.newtype(:vcsrepo) do
         end
       when :bare
         return is == :bare
+      when :mirror
+        return is == :mirror
       end
     end
 
@@ -78,6 +80,12 @@ Puppet::Type.newtype(:vcsrepo) do
     end
 
     newvalue :bare, :required_features => [:bare_repositories] do
+      if !provider.exists?
+        provider.create
+      end
+    end
+
+    newvalue :mirror, :required_features => [:bare_repositories] do
       if !provider.exists?
         provider.create
       end
@@ -227,7 +235,7 @@ Puppet::Type.newtype(:vcsrepo) do
   newparam :conflict do
     desc "The action to take if conflicts exist between repository and working copy"
   end
-  
+
   newparam :trust_server_cert do
     desc "Trust server certificate"
     newvalues(:true, :false)

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -10,7 +10,7 @@ end
    remote/origin/foo
 
 branches
-    end
+  end
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
     :name     => 'test',
     :ensure   => :present,
@@ -111,6 +111,24 @@ branches
       end
     end
 
+    context "with an ensure of mirror" do
+      context "with revision" do
+        it "should raise an error" do
+          resource[:ensure] = :mirror
+          expect { provider.create }.to raise_error Puppet::Error, /cannot set a revision.+bare/i
+        end
+      end
+      context "without revision" do
+        it "should just execute 'git clone --mirror'" do
+          resource[:ensure] = :mirror
+          resource.delete(:revision)
+          provider.expects(:git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
+          provider.expects(:update_remotes)
+          provider.create
+        end
+      end
+    end
+
     context "when a source is not given" do
       context "when the path does not exist" do
         it "should execute 'git init'" do
@@ -156,6 +174,14 @@ branches
         provider.expects(:working_copy_exists?).returns(false)
         provider.expects(:git).with('init', '--bare')
         provider.create
+      end
+
+      it "should raise an exeption" do
+        resource[:ensure] = :mirror
+        resource.delete(:source)
+        resource.delete(:revision)
+
+        expect { provider.create }.to raise_error Puppet::Error, /cannot init repository with mirror.+try bare/i
       end
     end
 


### PR DESCRIPTION
Example:

```
vcsrepo { '/path/to/repo':
  ensure   => mirror,
  provider => git,
  source   => 'git://example.com/repo.git',
}
```