### PR TITLE
Bring stderr output to the Puppet visible output

### DIFF
--- a/lib/puppet/provider/vcsrepo/cvs.rb
+++ b/lib/puppet/provider/vcsrepo/cvs.rb
@@ -127,9 +127,9 @@ Puppet::Type.type(:vcsrepo).provide(:cvs, :parent => Puppet::Provider::Vcsrepo) 
 
     if @resource.value(:user) and @resource.value(:user) != Facter['id'].value
       Puppet.debug "Running as user " + @resource.value(:user)
-      Puppet::Util::Execution.execute([:cvs, *args], :uid => @resource.value(:user), :custom_environment => e)
+      Puppet::Util::Execution.execute([:cvs, *args], :uid => @resource.value(:user), :custom_environment => e, :combine => true)
     else
-      Puppet::Util::Execution.execute([:cvs, *args], :custom_environment => e)
+      Puppet::Util::Execution.execute([:cvs, *args], :custom_environment => e, :combine => true)
     end
   end
 end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -472,7 +472,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
       end
     elsif @resource.value(:user) and @resource.value(:user) != Facter['id'].value
       env = Etc.getpwnam(@resource.value(:user))
-      Puppet::Util::Execution.execute("git #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true, :custom_environment => {'HOME' => env['dir']})
+      Puppet::Util::Execution.execute("git #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true, :custom_environment => {'HOME' => env['dir']}, :combine => true)
     else
       git(*args)
     end

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -122,7 +122,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, :parent => Puppet::Provider::Vcsrepo) d
     end
     if @resource.value(:user) and @resource.value(:user) != Facter['id'].value
       args.map! { |a| if a =~ /\s/ then "'#{a}'" else a end }  # Adds quotes to arguments with whitespaces.
-      Puppet::Util::Execution.execute("hg #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true)
+      Puppet::Util::Execution.execute("hg #{args.join(' ')}", :uid => @resource.value(:user), :failonfail => true, :combine => true)
     else
       hg(*args)
     end

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
         resource[:source] = ':ext:source@example.com:/foo/bar'
         resource[:revision] = 'an-unimportant-value'
         expects_chdir('/tmp')
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :custom_environment => {})
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :custom_environment => {}, :combine => true)
         provider.create
       end
 
@@ -32,14 +32,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
         resource[:revision] = 'an-unimportant-value'
         resource[:user] = 'muppet'
         expects_chdir('/tmp')
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :uid => 'muppet', :custom_environment => {})
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :uid => 'muppet', :custom_environment => {}, :combine => true)
         provider.create
       end
 
       it "should just execute 'cvs checkout' without a revision" do
         resource[:source] = ':ext:source@example.com:/foo/bar'
         resource.delete(:revision)
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {})
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {}, :combine => true)
         provider.create
       end
 
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
           resource[:source] = ':ext:source@example.com:/foo/bar'
           resource[:compression] = '3'
           resource.delete(:revision)
-          Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), '-z', '3', 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {})
+          Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), '-z', '3', 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {}, :combine => true)
           provider.create
         end
       end
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
     context "when a source is not given" do
       it "should execute 'cvs init'" do
         resource.delete(:source)
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:path), 'init'], :custom_environment => {})
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:path), 'init'], :custom_environment => {}, :combine => true)
         provider.create
       end
     end
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
 
     it "should use 'cvs update -dr'" do
       expects_chdir
-      Puppet::Util::Execution.expects(:execute).with([:cvs, 'update', '-dr', @tag, '.'], :custom_environment => {})
+      Puppet::Util::Execution.expects(:execute).with([:cvs, 'update', '-dr', @tag, '.'], :custom_environment => {}, :combine => true)
       provider.revision = @tag
     end
   end


### PR DESCRIPTION
Up for discussion, this change is only for git, hg and cvs right now.

I wanted to see the stderr output, and :combine will write it to stdout, so its visible in the Puppet report