### PR TITLE
(FM-5559) Readme and changelog edits for signoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,114 +1,144 @@
 # Change Log
+
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.4.0] - Supported Release
+## [1.4.0] - 2015-09-06 Supported Release
+
 ### Summary
+
 Small release for a new feature and added compatibility.
 
 ### Features
-- Now clone your git repository as a mirror or bare repo!
-- STDERR has been added to Puppet's output
-- Added Debian 8 and Ubuntu 16.04 compatibility
 
-## [1.3.2] - Supported Release
-###Summary
+- Git repositories can be cloned as mirror or bare repos.
+- Added STDERR to Puppet's output.
+- Added Debian 8 and Ubuntu 16.04 compatibility.
+
+## [1.3.2] - 2015-12-08 Supported Release
+
+### Summary
 
 Small release for support of newer PE versions. This increments the version of PE in the metadata.json file.
 
 ## [1.3.1] - 2015-07-28 Supported Release
-###Summary
-This release includes a number of bugfixes along with some test updates.
+
+### Summary
+
+This release includes a number of bugfixes and test updates.
 
 ### Fixed
-- Fix for detached HEAD on git 2.4+
-- Git provider doesn't ignore revision property when depth is used (MODULES-2131)
-- Test fixes
-- Check if submodules == true before calling update_submodules
+
+- Fix for detached HEAD on git 2.4+.
+- Git provider doesn't ignore revision property when depth is used (MODULES-2131).
+- Tests fixed.
+- Check if submodules == true before calling update_submodules.
 
 ## [1.3.0] - 2015-05-19 Supported Release
+
 ### Summary
+
 This release adds git provider remote handling, svn conflict resolution, and fixes the git provider when /tmp is mounted noexec.
 
 ### Added
-- `source` property now takes a hash of sources for the git provider's remotes
-- Add `submodules` parameter to skip submodule initialization for git provider
-- Add `conflict` to svn provider to resolve conflicts
-- Add `branch` parameter to specify clone branch
-- Readme rewrite
+
+- `source` property now takes a hash of sources for the git provider's remotes.
+- Added `submodules` parameter to skip submodule initialization for the git provider.
+- Added `conflict` to the svn provider to resolve conflicts.
+- Added `branch` parameter to specify clone branch.
+- Readme rewritten.
 
 ### Fixed
-- The git provider now works even if `/tmp` is noexec
+
+- The git provider now works even if `/tmp` is noexec.
 
 ## [1.2.0] - 2014-11-04 Supported Release
+
 ### Summary
+
 This release includes some improvements for git, mercurial, and cvs providers, and fixes the bug where there were warnings about multiple default providers.
 
 ### Added
+
 - Update git and mercurial providers to set UID with `Puppet::Util::Execution.execute` instead of `su`
 - Allow git excludes to be string or array
 - Add `user` feature to cvs provider
 
 ### Fixed
+
 - No more warnings about multiple default providers! (MODULES-428)
 
 ## [1.1.0] - 2014-07-14 Supported Release
+
 ### Summary
+
 This release adds a Perforce provider\* and corrects the git provider behavior
 when using `ensure => latest`.
 
 \*(Only git provider is currently supported.)
 
 ### Added
-- New Perforce provider
+
+- New Perforce provider.
 
 ### Fixed
-- (MODULES-660) Fix behavior with `ensure => latest` and detached HEAD
-- Spec test fixes
+
+- Fix behavior with `ensure => latest` and detached HEAD. (MODULES-660)
+- Spec test fixes.
 
 ## [1.0.2] - 2014-06-30 Supported Release
+
 ### Summary
+
 This supported release adds SLES 11 to the list of compatible OSs and
 documentation updates for support.
 
 ## [1.0.1] - 2014-06-17 Supported Release
+
 ### Summary
+
 This release is the first supported release of vcsrepo. The readme has been
 greatly improved.
 
 ### Added
-- Updated and expanded readme to follow readme template
+
+- Updated and expanded readme to follow readme template.
 
 ### Fixed
-- Remove SLES from compatability metadata
-- Unpin rspec development dependencies
-- Update acceptance level testing
+
+- Remove SLES from compatability metadata.
+- Unpin rspec development dependencies.
+- Update acceptance level testing.
 
 ## [1.0.0] - 2014-06-04
+
 ### Summary
 
 This release focuses on a number of bugfixes, and also has some
 new features for Bzr and Git.
 
 ### Added
+
 - Bzr:
- - Call set_ownership
+ - Call set_ownership.
 - Git:
- - Add ability for shallow clones
- - Use -a and desired for HARD resets
- - Use rev-parse to get tag canonical revision
+ - Add ability for shallow clones.
+ - Use -a and desired for HARD resets.
+ - Use rev-parse to get tag canonical revision.
 
 ### Fixed
+
 - HG:
- - Only add ssh options when it's talking to the network
+ - Only add ssh options when it's talking to the network.
 - Git:
- - Fix for issue with detached HEAD
- - force => true will now destroy and recreate repo
- - Actually use the remote parameter
- - Use origin/master instead of origin/HEAD when on master
+ - Fix for issue with detached HEAD.
+ - `force => true` will now destroy and recreate repo.
+ - Actually use the remote parameter.
+ - Use origin/master instead of origin/HEAD when on master.
 - SVN:
- - Fix svnlook behavior with plain directories
+ - Fix svnlook behavior with plain directories.
 
 ## 0.2.0 - 2013-11-13
+
 ### Summary
 
 This release mainly focuses on a number of bugfixes, which should
@@ -116,8 +146,9 @@ significantly improve the reliability of Git and SVN.  Thanks to
 our many contributors for all of these fixes!
 
 ### Added
+
 - Git:
- - Add autorequire for Package['git']
+ - Add autorequire for `Package['git']`.
 - HG:
  - Allow user and identity properties.
 - Bzr:
@@ -129,6 +160,7 @@ our many contributors for all of these fixes!
  - Allow for setting the CVS_RSH environment variable.
 
 ### Fixed
+
 - Handle Puppet::Util[::Execution].withenv for 2.x and 3.x properly.
 - Change path_empty? to not do full directory listing.
 - Overhaul spec tests to work with rspec2.
@@ -140,7 +172,7 @@ our many contributors for all of these fixes!
  - Use git checkout --force instead of short -f everywhere.
  - Update git provider to handle checking out into an existing (empty) dir.
 - SVN:
- - Handle force property. for svn.
+ - Handle force property.
  - Adds support for changing upstream repo url.
  - Check that the URL of the WC matches the URL from the manifest.
  - Changed from using "update" to "switch".

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
-#vcsrepo
+# vcsrepo
 
-####Table of Contents
+#### Table of contents
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
@@ -13,7 +13,7 @@
     * [CVS](#cvs)
     * [Mercurial](#mercurial)
     * [Perforce](#perforce)
-    * [Subversion](#subversion)  
+    * [Subversion](#subversion)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
     * [Type: vcsrepo](#type-vcsrepo)
         * [Providers](#providers)
@@ -22,11 +22,11 @@
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
-##Overview
+## Overview
 
 The vcsrepo module lets you use Puppet to easily deploy content from your version control system (VCS).
 
-##Module Description
+## Module description
 
 The vcsrepo module provides a single type with providers to support the following version control systems:
 
@@ -37,38 +37,38 @@ The vcsrepo module provides a single type with providers to support the followin
 * [Perforce](#perforce)
 * [Subversion](#subversion)
 
-**Note:** `git` is the only vcs provider officially [supported by Puppet Labs](https://forge.puppetlabs.com/supported).
+**Note:** `git` is the only vcs provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
 
-##Setup
+## Setup
 
-###Setup Requirements
+### Setup requirements
 
-The `vcsrepo` module does not install any VCS software for you. You must install a VCS before you can use this module.
+The vcsrepo module does not install any VCS software for you. You must install a VCS before you can use this module.
 
-Like Puppet in general, the `vcsrepo` module does not automatically create parent directories for the files it manages. Make sure to set up any needed directory structures before you get started.
+Like Puppet in general, the vcsrepo module does not automatically create parent directories for the files it manages. Set up any needed directory structures before you start.
 
-###Beginning with vcsrepo
+### Beginning with vcsrepo
 
 To create and manage a blank repository, define the type `vcsrepo` with a path to your repository and supply the `provider` parameter based on the [VCS you're using](#usage).
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
 }
 ~~~
 
-##Usage
+## Usage
 
-**Note:** `git` is the only vcsrepo provider officially [supported by Puppet Labs](https://forge.puppetlabs.com/supported).
+**Note:** `git` is the only vcsrepo provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
 
-###Git
+### Git
 
-####Create a blank repository
+#### Create a blank repository
 
-To create a blank repository, suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
+To create a blank repository suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -77,16 +77,16 @@ vcsrepo { '/path/to/repo':
 
 If you're managing a central or official repository, you might want to make it a bare repository. To do this, set `ensure` to 'bare':
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => bare,
   provider => git,
 }
 ~~~
 
-####Clone/pull a repository
+#### Clone/pull a repository
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -94,9 +94,9 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-If you want to clone your repository as bare or mirror, you can set `ensure` to 'bare' or 'mirror':
+To clone your repository as bare or mirror, you can set `ensure` to 'bare' or 'mirror':
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => mirror,
   provider => git,
@@ -108,7 +108,7 @@ By default, `vcsrepo` will use the HEAD of the source repository's master branch
 
 Branch name:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -119,7 +119,7 @@ vcsrepo { '/path/to/repo':
 
 SHA:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -130,7 +130,7 @@ vcsrepo { '/path/to/repo':
 
 Tag:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -141,7 +141,7 @@ vcsrepo { '/path/to/repo':
 
 To check out a branch as a specific user, supply the `user` parameter:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
@@ -153,9 +153,9 @@ vcsrepo { '/path/to/repo':
 
 To keep the repository at the latest revision, set `ensure` to 'latest'.
 
-**WARNING:** this overwrites any local changes to the repository:
+**WARNING:** This overwrites any local changes to the repository.
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => latest,
   provider => git,
@@ -166,7 +166,7 @@ vcsrepo { '/path/to/repo':
 
 To clone the repository but skip initializing submodules, set `submodules` to 'false':
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure     => latest,
   provider   => git,
@@ -175,55 +175,56 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-####Use multiple remotes with a repository
+#### Use multiple remotes with a repository
+
 In place of a single string, you can set `source` to a hash of one or more name => URL pairs:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => git,
   remote   => 'origin'
   source   => {
-    'origin'       => 'https://github.com/puppetlabs/puppetlabs-vcsrepo.git', 
+    'origin'       => 'https://github.com/puppetlabs/puppetlabs-vcsrepo.git',
     'other_remote' => 'https://github.com/other_user/puppetlabs-vcsrepo.git'
   },
 }
 ~~~
 
-**Note:** if you set `source` to a hash, one of the names you specify must match the value of the `remote` parameter. That remote serves as the upstream of your managed repository.
+**Note:** If you set `source` to a hash, one of the names you specify must match the value of the `remote` parameter. That remote serves as the upstream of your managed repository.
 
-####Connect via SSH
+#### Connect via SSH
 
-To connect to your source repository via SSH (e.g., 'username@server:…'), we recommend managing your SSH keys with Puppet and using the [`require`](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) metaparameter to make sure they are present before the `vcsrepo` resource is applied.
+To connect to your source repository via SSH (such as 'username@server:…'), we recommend managing your SSH keys with Puppet and using the [`require`](http://docs.puppet.com/references/stable/metaparameter.html#require) metaparameter to make sure they are present before the `vcsrepo` resource is applied.
 
 To use SSH keys associated with a user, specify the username in the `user` parameter:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => latest,
-  provider   => git,
-  source     => 'git://username@example.com/repo.git',
-  user       => 'toto', #uses toto's $HOME/.ssh setup
-  require    => File['/home/toto/.ssh/id_rsa'],
+  ensure   => latest,
+  provider => git,
+  source   => 'git://username@example.com/repo.git',
+  user     => 'toto', #uses toto's $HOME/.ssh setup
+  require  => File['/home/toto/.ssh/id_rsa'],
 }
 ~~~
 
-###Bazaar
+### Bazaar
 
-####Create a blank repository
+#### Create a blank repository
 
 To create a blank repository, suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => bzr,
 }
 ~~~
 
-####Branch from an existing repository
+#### Branch from an existing repository
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => bzr,
@@ -233,7 +234,7 @@ vcsrepo { '/path/to/repo':
 
 To branch from a specific revision, set `revision` to a valid [Bazaar revision spec](http://wiki.bazaar.canonical.com/BzrRevisionSpec):
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => bzr,
@@ -242,36 +243,36 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-####Connect via SSH
+#### Connect via SSH
 
-To connect to your source repository via SSH (e.g., `'bzr+ssh://...'` or `'sftp://...,'`), we recommend using the [`require`](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) metaparameter to make sure your SSH keys are present before the `vcsrepo` resource is applied:
+To connect to your source repository via SSH (such as `'bzr+ssh://...'` or `'sftp://...,'`), we recommend using the [`require`](http://docs.puppet.com/references/stable/metaparameter.html#require) metaparameter to make sure your SSH keys are present before the `vcsrepo` resource is applied:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => latest,
-  provider   => bzr,
-  source     => 'bzr+ssh://bzr.example.com/some/path',
-  user       => 'toto', #uses toto's $HOME/.ssh setup
-  require    => File['/home/toto/.ssh/id_rsa'],
+  ensure   => latest,
+  provider => bzr,
+  source   => 'bzr+ssh://bzr.example.com/some/path',
+  user     => 'toto', #uses toto's $HOME/.ssh setup
+  require  => File['/home/toto/.ssh/id_rsa'],
 }
 ~~~
 
-###CVS
+### CVS
 
-####Create a blank repository
+#### Create a blank repository
 
-To create a blank repository, suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
+To create a blank repository suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => cvs,
 }
 ~~~
 
-####Checkout/update from a repository
+#### Checkout/update from a repository
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/workspace':
   ensure   => present,
   provider => cvs,
@@ -281,8 +282,8 @@ vcsrepo { '/path/to/workspace':
 
 To get a specific module on the current mainline, supply the `module` parameter:
 
-~~~
-vcsrepo {'/vagrant/lockss-daemon-source':
+~~~ puppet
+vcsrepo { '/vagrant/lockss-daemon-source':
   ensure   => present,
   provider => cvs,
   source   => ':pserver:anonymous@lockss.cvs.sourceforge.net:/cvsroot/lockss',
@@ -292,7 +293,7 @@ vcsrepo {'/vagrant/lockss-daemon-source':
 
 To set the GZIP compression levels for your repository history, use the `compression` parameter:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/workspace':
   ensure      => present,
   provider    => cvs,
@@ -303,7 +304,7 @@ vcsrepo { '/path/to/workspace':
 
 To get a specific revision, set `revision` to the revision number.
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/workspace':
   ensure      => present,
   provider    => cvs,
@@ -315,7 +316,7 @@ vcsrepo { '/path/to/workspace':
 
 You can also set `revision` to a tag:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/workspace':
   ensure      => present,
   provider    => cvs,
@@ -325,38 +326,38 @@ vcsrepo { '/path/to/workspace':
 }
 ~~~
 
-####Connect via SSH
+#### Connect via SSH
 
-To connect to your source repository via SSH, we recommend using the [`require`](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) metaparameter to make sure your SSH keys are present before the `vcsrepo` resource is applied:
+To connect to your source repository via SSH, we recommend using the [`require`](http://docs.puppet.com/references/stable/metaparameter.html#require) metaparameter to make sure your SSH keys are present before the `vcsrepo` resource is applied:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => latest,
-  provider   => cvs,
-  source     => ':pserver:anonymous@example.com:/sources/myproj',
-  user       => 'toto', #uses toto's $HOME/.ssh setup
-  require    => File['/home/toto/.ssh/id_rsa'],
+  ensure   => latest,
+  provider => cvs,
+  source   => ':pserver:anonymous@example.com:/sources/myproj',
+  user     => 'toto', #uses toto's $HOME/.ssh setup
+  require  => File['/home/toto/.ssh/id_rsa'],
 }
 ~~~
 
-###Mercurial
+### Mercurial
 
-####Create a blank repository
+#### Create a blank repository
 
-To create a blank repository, suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
+To create a blank repository suitable for use as a central repository, define `vcsrepo` without `source` or `revision`:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
 }
 ~~~
 
-####Clone/pull & update a repository
+#### Clone/pull and update a repository
 
 To get the default branch tip:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
@@ -366,7 +367,7 @@ vcsrepo { '/path/to/repo':
 
 For a specific changeset, use `revision`:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
@@ -377,7 +378,7 @@ vcsrepo { '/path/to/repo':
 
 You can also set `revision` to a tag:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
@@ -388,7 +389,7 @@ vcsrepo { '/path/to/repo':
 
 To check out as a specific user:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
@@ -399,7 +400,7 @@ vcsrepo { '/path/to/repo':
 
 To specify an SSH identity key:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => hg,
@@ -410,51 +411,51 @@ vcsrepo { '/path/to/repo':
 
 To specify a username and password for HTTP Basic authentication:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure   => latest,
-  provider => hg,
-  source   => 'http://hg.example.com/myrepo',
+  ensure              => latest,
+  provider            => hg,
+  source              => 'http://hg.example.com/myrepo',
   basic_auth_username => 'hgusername',
   basic_auth_password => 'hgpassword',
 }
 ~~~
 
-####Connect via SSH 
+#### Connect via SSH
 
-To connect to your source repository via SSH (e.g., `'ssh://...'`), we recommend using the [`require` metaparameter](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) to make sure your SSH keys are present before the `vcsrepo` resource is applied:
+To connect to your source repository via SSH (such as `'ssh://...'`), we recommend using the [`require` metaparameter](http://docs.puppet.com/references/stable/metaparameter.html#require) to make sure your SSH keys are present before the `vcsrepo` resource is applied:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => latest,
-  provider   => hg,
-  source     => 'ssh://hg.example.com//path/to/myrepo',
-  user       => 'toto', #uses toto's $HOME/.ssh setup
-  require    => File['/home/toto/.ssh/id_rsa'],
+  ensure   => latest,
+  provider => hg,
+  source   => 'ssh://hg.example.com//path/to/myrepo',
+  user     => 'toto', #uses toto's $HOME/.ssh setup
+  require  => File['/home/toto/.ssh/id_rsa'],
 }
 ~~~
 
-###Perforce
+### Perforce
 
-####Create an empty workspace
+#### Create an empty workspace
 
-To set up the connection to your Perforce service, set `p4config` to the location of a valid Perforce [config file](http://www.perforce.com/perforce/doc.current/manuals/p4guide/chapter.configuration.html#configuration.settings.configfiles) stored on the node: 
+To set up the connection to your Perforce service, set `p4config` to the location of a valid Perforce [config file](http://www.perforce.com/perforce/doc.current/manuals/p4guide/chapter.configuration.html#configuration.process.configfiles) stored on the node:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => present,
-  provider   => p4,
-  p4config   => '/root/.p4config'
+  ensure   => present,
+  provider => p4,
+  p4config => '/root/.p4config'
 }
 ~~~
 
-**Note:** If you don't include the `P4CLIENT` setting in your config file, the provider generates a workspace name based on the digest of `path` and the node's hostname (e.g., `puppet-91bc00640c4e5a17787286acbe2c021c`):
+**Note:** If you don't include the `P4CLIENT` setting in your config file, the provider generates a workspace name based on the digest of `path` and the node's hostname (such as `puppet-91bc00640c4e5a17787286acbe2c021c`).
 
-####Create/update and sync a Perforce workspace
+#### Create/update and sync a Perforce workspace
 
 To sync a depot path to head, set `ensure` to 'latest':
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => latest,
   provider => p4,
@@ -464,7 +465,7 @@ vcsrepo { '/path/to/repo':
 
 To sync to a specific changelist, specify its revision number with the `revision` parameter:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => p4,
@@ -475,7 +476,7 @@ vcsrepo { '/path/to/repo':
 
 You can also set `revision` to a label:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => p4,
@@ -484,22 +485,22 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-###Subversion
+### Subversion
 
-####Create a blank repository
+#### Create a blank repository
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => svn,
 }
 ~~~
 
-####Check out from an existing repository
+#### Check out from an existing repository
 
 Provide a `source` pointing to the branch or tag you want to check out:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => svn,
@@ -509,7 +510,7 @@ vcsrepo { '/path/to/repo':
 
 You can also designate a specific revision:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure   => present,
   provider => svn,
@@ -518,11 +519,11 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-####Use a specific Subversion configuration directory 
+#### Use a specific Subversion configuration directory
 
 Use the `configuration` parameter to designate the directory that contains your Subversion configuration files (typically, '/path/to/.subversion'):
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
   ensure        => present,
   provider      => svn,
@@ -531,76 +532,76 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-####Connect via SSH 
+#### Connect via SSH
 
-To connect to your source repository via SSH (e.g., `'svn+ssh://...'`), we recommend using the [`require` metaparameter](http://docs.puppetlabs.com/references/stable/metaparameter.html#require) to make sure your SSH keys are present before the `vcsrepo` resource is applied:
+To connect to your source repository via SSH (such as `'svn+ssh://...'`), we recommend using the [`require` metaparameter](http://docs.puppet.com/references/stable/metaparameter.html#require) to make sure your SSH keys are present before the `vcsrepo` resource is applied:
 
-~~~
+~~~ puppet
 vcsrepo { '/path/to/repo':
-  ensure     => latest,
-  provider   => svn,
-  source     => 'svn+ssh://svnrepo/hello/branches/foo',
-  user       => 'toto', #uses toto's $HOME/.ssh setup
-  require    => File['/home/toto/.ssh/id_rsa'],
+  ensure   => latest,
+  provider => svn,
+  source   => 'svn+ssh://svnrepo/hello/branches/foo',
+  user     => 'toto', #uses toto's $HOME/.ssh setup
+  require  => File['/home/toto/.ssh/id_rsa'],
 }
 ~~~
 
-##Reference
+## Reference
 
-###Type: vcsrepo
+### Type: vcsrepo
 
 The vcsrepo module adds only one type with several providers. Each provider abstracts a different VCS, and each provider includes a set of features according to its needs.
 
-####Providers
+#### Providers
 
 **Note:** Not all features are available with all providers.
 
-#####`git` - Supports the Git VCS.
+##### `git` - Supports the Git VCS.
 
 Features: `bare_repositories`, `depth`, `multiple_remotes`, `reference_tracking`, `ssh_identity`, `submodules`, `user`
 
 Parameters: `depth`, `ensure`, `excludes`, `force`, `group`, `identity`, `owner`, `path`, `provider`, `remote`, `revision`, `source`, `user`
 
-#####`bzr` - Supports the Bazaar VCS.
+##### `bzr` - Supports the Bazaar VCS.
 
 Features: `reference_tracking`
 
 Parameters: `ensure`, `excludes`, `force`, `group`, `owner`, `path`, `provider`, `revision`, `source`
 
-#####`cvs` - Supports the CVS VCS.
+##### `cvs` - Supports the CVS VCS.
 
 Features: `cvs_rsh`, `gzip_compression`, `modules`, `reference_tracking`, `user`
 
 Parameters: `compression`, `cvs_rsh`, `ensure`, `excludes`, `force`, `group`, `module`, `owner`, `path`, `provider`
 
-#####`hg` - Supports the Mercurial VCS.
+##### `hg` - Supports the Mercurial VCS.
 
 Features: `reference_tracking`, `ssh_identity`, `user`
 
 Parameters: `ensure`, `excludes`, `force`, `group`, `identity`, `owner`, `path`, `provider`, `revision`, `source`, `user`
 
-#####`p4` - Supports the Perforce VCS.
+##### `p4` - Supports the Perforce VCS.
 
 Features: `p4config`, `reference_tracking`
 
 Parameters: `ensure`, `excludes`, `force`, `group`, `owner`, `p4config`, `path`, `provider`, `revision`, `source`
 
-#####`svn` - Supports the Subversion VCS.
+##### `svn` - Supports the Subversion VCS.
 
 Features: `basic_auth`, `configuration`, `conflict`, `depth`, `filesystem_types`, `reference_tracking`
 
 Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conflict`, `ensure`, `excludes`, `force`, `fstype`, `group`, `owner`, `path`, `provider`, `revision`, `source`, `trust_server_cert`
 
-####Features
+#### Features
 
 **Note:** Not all features are available with all providers.
 
 * `bare_repositories` - Differentiates between bare repositories and those with working copies. (Available with `git`.)
-* `basic_auth` -  Supports HTTP Basic authentication. (Available with `svn`.)
+* `basic_auth` - Supports HTTP Basic authentication. (Available with `svn`.)
 * `conflict` - Lets you decide how to resolve any conflicts between the source repository and your working copy. (Available with `svn`.)
 * `configuration` - Lets you specify the location of your configuration files. (Available with `svn`.)
 * `cvs_rsh` - Understands the `CVS_RSH` environment variable. (Available with `cvs`.)
-* `depth` - Supports shallow clones in `git` or sets scope limit in `svn`. (Available with `git` and `svn`.)
+* `depth` - Supports shallow clones in `git` or sets the scope limit in `svn`. (Available with `git` and `svn`.)
 * `filesystem_types` - Supports multiple types of filesystem. (Available with `svn`.)
 * `gzip_compression` - Supports explicit GZip compression levels. (Available with `cvs`.)
 * `modules` - Lets you choose a specific repository module. (Available with `cvs`.)
@@ -611,148 +612,148 @@ Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conf
 * `p4config` - Supports setting the `P4CONFIG` environment. (Available with `p4`.)
 * `submodules` - Supports repository submodules which can be optionally initialized. (Available with `git`.)
 
-####Parameters
+#### Parameters
 
 All parameters are optional, except where specified otherwise.
 
 ##### `basic_auth_password`
 
-Specifies the password for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string. Default: none. 
+Specifies the password for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string. Default: none.
 
 ##### `basic_auth_username`
 
-Specifies the username for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string. Default: none. 
+Specifies the username for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string. Default: none.
 
 ##### `compression`
 
-Sets the GZIP compression level for the repository history. (Requires the `gzip_compression` feature.) Valid options: an integer between 0 and 6. Default: none. 
+Sets the GZIP compression level for the repository history. (Requires the `gzip_compression` feature.) Valid options: an integer between 0 and 6. Default: none.
 
 ##### `configuration`
 
-Sets the configuration directory to use. (Requires the `configuration` feature.) Valid options: a string containing an absolute path. Default: none. 
+Sets the configuration directory to use. (Requires the `configuration` feature.) Valid options: a string containing an absolute path. Default: none.
 
 ##### `conflict`
 
-Tells Subversion how to resolve any conflicts between the source repository and your working copy. (Requires the `conflict` feature.) Valid options: 'base', 'mine-full', 'theirs-full', and 'working'. Default: none. 
+Tells Subversion how to resolve any conflicts between the source repository and your working copy. (Requires the `conflict` feature.) Valid options: 'base', 'mine-full', 'theirs-full', and 'working'. Default: none.
 
 ##### `cvs_rsh`
 
-Provides a value for the `CVS_RSH` environment variable. (Requires the `cvs_rsh` feature.) Valid options: a string. Default: none. 
+Provides a value for the `CVS_RSH` environment variable. (Requires the `cvs_rsh` feature.) Valid options: a string. Default: none.
 
 ##### `depth`
 
-In `git` sets the number of commits to include when creating a shallow clone. (Requires the `depth` feature.) Valid options: an integer. Default: none. 
+In `git`, `depth` sets the number of commits to include when creating a shallow clone. (Requires the `depth` feature.) Valid options: an integer. Default: none.
 
-In `svn` instructs Subversion to limit the scope of an operation to a particular tree depth. (Requires the `depth` feature.) Valid options: 'empty', 'files', 'immediates', 'infinity'. Default: none. 
+In `svn`, `depth` limits the scope of an operation to the specified tree depth. (Requires the `depth` feature.) Valid options: 'empty', 'files', 'immediates', 'infinity'. Default: none.
 
 ##### `ensure`
 
-Specifies whether the repository should exist. Valid options: 'present', 'bare', 'absent', and 'latest'. Default: 'present'. 
+Specifies whether the repository should exist. Valid options: 'present', 'bare', 'absent', and 'latest'. Default: 'present'.
 
 ##### `excludes`
 
-Lists any files the repository shouldn't track (similar to .gitignore). Valid options: a string (separate multiple values with the newline character). Default: none. 
+Lists any files the repository shouldn't track (similar to .gitignore). Valid options: a string (separate multiple values with the newline character). Default: none.
 
 ##### `force`
 
-Specifies whether to delete any existing files in the repository path if creating a new repository. **Use with care.** Valid options: 'true' and 'false'. Default: 'false'. 
+Specifies whether to delete any existing files in the repository path if creating a new repository. **Use with care.** Valid options: 'true' and 'false'. Default: 'false'.
 
 ##### `fstype`
 
-Sets the filesystem type. (Requires the `filesystem_types` feature.) Valid options: 'fsfs' or 'bdb'. Default: none. 
+Sets the filesystem type. (Requires the `filesystem_types` feature.) Valid options: 'fsfs' or 'bdb'. Default: none.
 
 ##### `group`
 
-Specifies a group to own the repository files. Valid options: a string containing a group name or GID. Default: none. 
+Specifies a group to own the repository files. Valid options: a string containing a group name or GID. Default: none.
 
 ##### `identity`
 
-Specifies an identity file to use for SSH authentication. (Requires the `ssh_identity` feature.) Valid options: a string containing an absolute path. Default: none. 
+Specifies an identity file to use for SSH authentication. (Requires the `ssh_identity` feature.) Valid options: a string containing an absolute path. Default: none.
 
 ##### `module`
 
-Specifies the repository module to manage. (Requires the `modules` feature.) Valid options: a string containing the name of a CVS module. Default: none. 
+Specifies the repository module to manage. (Requires the `modules` feature.) Valid options: a string containing the name of a CVS module. Default: none.
 
 ##### `owner`
 
-Specifies a user to own the repository files. Valid options: a string containing a username or UID. Default: none. 
+Specifies a user to own the repository files. Valid options: a string containing a username or UID. Default: none.
 
 ##### `p4config`
 
-Specifies a config file that contains settings for connecting to the Perforce service. (Requires the `p4config` feature.) Valid options: a string containing the absolute path to a valid [Perforce config file](http://www.perforce.com/perforce/doc.current/manuals/p4guide/chapter.configuration.html#configuration.settings.configfiles). Default: none. 
+Specifies a config file that contains settings for connecting to the Perforce service. (Requires the `p4config` feature.) Valid options: a string containing the absolute path to a valid [Perforce config file](http://www.perforce.com/perforce/doc.current/manuals/p4guide/chapter.configuration.html#configuration.process.configfiles). Default: none.
 
 ##### `path`
 
-Specifies a location for the managed repository. Valid options: a string containing an absolute path. Default: the title of your declared resource. 
+Specifies a location for the managed repository. Valid options: a string containing an absolute path. Default: the title of your declared resource.
 
 ##### `provider`
 
-*Required.* Specifies the backend to use for this vcsrepo resource. Valid options: 'bzr', 'cvs', 'git', 'hg', 'p4', and 'svn'. 
+*Required.* Specifies the backend to use for this vcsrepo resource. Valid options: 'bzr', 'cvs', 'git', 'hg', 'p4', and 'svn'.
 
 ##### `remote`
 
-Specifies the remote repository to track. (Requires the `multiple_remotes` feature.) Valid options: a string containing one of the remote names specified in `source`. Default: 'origin'. 
+Specifies the remote repository to track. (Requires the `multiple_remotes` feature.) Valid options: a string containing one of the remote names specified in `source`. Default: 'origin'.
 
 ##### `revision`
 
 Sets the revision of the repository. Valid options vary by provider:
 
-* `git` - a string containing a Git branch name, or a commit SHA or tag
-* `bzr` - a string containing a Bazaar [revision spec](http://wiki.bazaar.canonical.com/BzrRevisionSpec)
-* `cvs` - a string containing a CVS [tag or revision number](http://www.thathost.com/wincvs-howto/cvsdoc/cvs_4.html)
-* `hg` - a string containing a Mercurial [changeset ID](http://mercurial.selenic.com/wiki/ChangeSetID) or [tag](http://mercurial.selenic.com/wiki/Tag)
-* `p4` - a string containing a Perforce [change number, label name, client name, or date spec](http://www.perforce.com/perforce/r12.1/manuals/cmdref/o.fspecs.html)
-* `svn` - a string containing a Subversion [revision number](http://svnbook.red-bean.com/en/1.7/svn.basic.in-action.html#svn.basic.in-action.revs), [revision keyword, or revision date](http://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html)
+* `git` - A string containing a Git branch name, or a commit SHA or tag.
+* `bzr` - A string containing a Bazaar [revision spec](http://wiki.bazaar.canonical.com/BzrRevisionSpec).
+* `cvs` - A string containing a CVS [tag or revision number](http://www.thathost.com/wincvs-howto/cvsdoc/cvs_4.html).
+* `hg` - A string containing a Mercurial [changeset ID](https://www.mercurial-scm.org/wiki/ChangeSetID) or [tag](https://www.mercurial-scm.org/wiki/Tag).
+* `p4` - A string containing a Perforce [change number, label name, client name, or date spec](http://www.perforce.com/perforce/r12.1/manuals/cmdref/o.fspecs.html).
+* `svn` - A string containing a Subversion [revision number](http://svnbook.red-bean.com/en/1.7/svn.basic.in-action.html#svn.basic.in-action.revs), [revision keyword, or revision date](http://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html).
 
-Default: none. 
+Default: none.
 
 ##### `source`
 
 Specifies a source repository to serve as the upstream for your managed repository. Default: none. Valid options vary by provider:
 
-* `git` - a string containing a [Git repository URL](https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#_git_urls_a_id_urls_a) or a hash of name => URL mappings. See also [`remote`](#remote).
-* `bzr` - a string containing a Bazaar branch location
-* `cvs` - a string containing a CVS root
-* `hg` - a string containing the local path or URL of a Mercurial repository
-* `p4` - a string containing a Perforce depot path
-* `svn` - a string containing a Subversion repository URL
+* `git` - A string containing a [Git repository URL](https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#_git_urls_a_id_urls_a) or a hash of `name => URL` mappings. See also [`remote`](#remote).
+* `bzr` - A string containing a Bazaar branch location.
+* `cvs` - A string containing a CVS root.
+* `hg` - A string containing the local path or URL of a Mercurial repository.
+* `p4` - A string containing a Perforce depot path.
+* `svn` - A string containing a Subversion repository URL.
 
-Default: none. 
+Default: none.
 
 ##### `submodules`
 
-Specifies whether to initialize and update each submodule in the repository. (Requires the `submodules` feature.) Valid options: 'true' and 'false'. Default: 'true'. 
+Specifies whether to initialize and update each submodule in the repository. (Requires the `submodules` feature.) Valid options: 'true' and 'false'. Default: 'true'.
 
 ##### `trust_server_cert`
 
-Instructs Subversion to accept SSL server certificates issued by unknown certificate authorities. Valid options: 'true' and 'false'. Default: 'false'. 
+Instructs Subversion to accept SSL server certificates issued by unknown certificate authorities. Valid options: 'true' and 'false'. Default: 'false'.
 
 ##### `user`
 
 Specifies the user to run as for repository operations. (Requires the `user` feature.) Valid options: a string containing a username or UID. Default: none.
 
-##Limitations
+## Limitations
 
-Git is the only VCS provider officially [supported](https://forge.puppetlabs.com/supported) by Puppet Labs.
+Git is the only VCS provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
 
 This module has been tested with Puppet 2.7 and higher.
 
 The module has been tested on:
 
 * CentOS 5/6/7
-* Debian 6/7
+* Debian 6/7/8
 * Oracle 5/6/7
 * Red Hat Enterprise Linux 5/6/7
 * Scientific Linux 5/6/7
 * SLES 10/11/12
-* Ubuntu 10.04/12.04/14.04
+* Ubuntu 10.04/12.04/14.04/16.04
 
 Testing on other platforms has been light and cannot be guaranteed.
 
-##Development
+## Development
 
-Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
+Puppet Inc. modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
 
 We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
-You can read the complete module contribution guide [on the Puppet Labs wiki.](http://projects.puppetlabs.com/projects/module-site/wiki/Module_contributing)
+You can read the complete module contribution guide [on the Puppet documentation site.](https://docs.puppet.com/guides/module_guides/bgtm.html)


### PR DESCRIPTION
-   Added missing Debian 8 and Ubuntu 16.04 platforms to the readme.
-   Standardized/reverted line ending characters throughout the readme.
-   Added `puppet` syntax highlighting to code blocks.
-   Aligned hash rocket in Puppet code blocks.
-   Standardized spacing between heading Markdown and text.
-   Standardized sentence case on headings.
-   Updated section targets in Perforce docs links.
-   Fixed a broken link to the Mercurial docs.
-   Updated puppetlabs.com URLs to puppet.com.
-   Updated Puppet Labs references to Puppet Inc.
-   Updated a Projects wiki link to the docs site.
-   Added dates to the 1.4.0 and 1.3.2 releases on the changelog.