### PR TITLE
Make :source a property, + some refactoring

### DIFF
--- a/lib/puppet/provider/vcsrepo.rb
+++ b/lib/puppet/provider/vcsrepo.rb
@@ -5,6 +5,17 @@ require 'fileutils'
 # Abstract
 class Puppet::Provider::Vcsrepo < Puppet::Provider
 
+  def check_force
+    if path_exists? and not path_empty?
+      if @resource.value(:force)
+        notice "Removing %s to replace with desired repository." % @resource.value(:path)
+        destroy
+      else
+        raise Puppet::Error, "Path %s exists and is not the desired repository." % @resource.value(:path)
+      end
+    end
+  end
+
   private
 
   def set_ownership

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -10,6 +10,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes, :user, :depth, :branch, :submodules
 
   def create
+    check_force
     if @resource.value(:revision) and ensure_bare_or_mirror?
       fail("Cannot set a revision (#{@resource.value(:revision)}) on a bare repository")
     end
@@ -18,10 +19,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
         fail("Cannot init repository with mirror option, try bare instead")
       end
 
-      init_repository(@resource.value(:path))
+      init_repository
     else
       clone_repository(default_url, @resource.value(:path))
-      update_remotes
+      update_remotes(@resource.value(:source))
 
       if @resource.value(:revision)
         checkout
@@ -112,7 +113,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
       if @resource.value(:source).has_key?(@resource.value(:remote))
         @resource.value(:source)[@resource.value(:remote)]
       else
-        fail("You must specify the URL for #{@resource.value(:remote)} in the :source hash")
+        fail("You must specify the URL for remote '#{@resource.value(:remote)}' in the :source hash")
       end
     else
       @resource.value(:source)
@@ -120,10 +121,27 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def working_copy_exists?
-    if @resource.value(:source) and File.exists?(File.join(@resource.value(:path), '.git', 'config'))
-      File.readlines(File.join(@resource.value(:path), '.git', 'config')).grep(/#{Regexp.escape(default_url)}/).any?
-    else
-      File.directory?(File.join(@resource.value(:path), '.git'))
+    # NOTE: a change in the `default_url` will tell the type that this repo
+    # doesn't exist (i.e. it triggers a "not the same repository" error).
+    # Thus, changing the `source` property from a string to a string (which
+    # changes the origin url), or if the @resource.value(:remote)'s url is
+    # changed, the provider will require force.
+    return false if not File.directory?(File.join(@resource.value(:path), '.git'))
+    at_path do
+      if @resource.value(:source)
+        begin
+          git('config', '--get', "remote.#{@resource.value(:remote)}.url").chomp == default_url
+        rescue Puppet::ExecutionFailure
+          return false
+        end
+      else
+        begin
+          git('status')
+          return true
+        rescue Puppet::ExecutionFailure
+          return false
+        end
+      end
     end
   end
 
@@ -131,8 +149,13 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     working_copy_exists? || bare_exists?
   end
 
+  def remove_remote(remote)
+    at_path do
+      git_with_identity('remote', 'remove', remote)
+    end
+  end
+
   def update_remote_url(remote_name, remote_url)
-    do_update = false
     current = git_with_identity('config', '-l')
 
     unless remote_url.nil?
@@ -153,19 +176,54 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   end
 
-  def update_remotes
+  def source
+    at_path do
+      remotes = git('remote').split("\n")
+      if remotes.size == 1
+        return git('config', '--get', "remote.#{remotes[0]}.url").chomp
+      else
+        Hash[remotes.map { |remote|
+          [remote, git('config', '--get', "remote.#{remote}.url").chomp]
+        }]
+      end
+    end
+  end
+
+  def source=(desired)
+    # NOTE: a change in the `default_url` will tell the type that this repo
+    # doesn't exist (i.e. it triggers a "not the same repository" error).
+    # Thus, a change from a string to a string (which changes the origin url),
+    # or if the @resource.value(:remote)'s url is changed, the provider will
+    # require force, without ever reaching this block. The recreation is
+    # duplicated here in case something changes in the `working_copy_exists?`
+    # logic.
+    current = source
+    if current.is_a?(Hash)
+      current.keys.each { |remote|
+        remove_remote(remote) if desired.is_a?(Hash) and not desired.has_key?(remote)
+        remove_remote(remote) if desired.is_a?(String) and remote != @resource.value(:remote)
+      }
+    end
+    if current.is_a?(String) and desired.is_a?(String)
+      create # recreate
+    else
+      update_remotes(desired)
+    end
+  end
+
+  def update_remotes(remotes)
     do_update = false
 
     # If supplied source is a hash of remote name and remote url pairs, then
     # we loop around the hash. Otherwise, we assume single url specified
     # in source property
-    if @resource.value(:source).is_a?(Hash)
-      @resource.value(:source).keys.sort.each do |remote_name|
-        remote_url = @resource.value(:source)[remote_name]
+    if remotes.is_a?(Hash)
+      remotes.keys.sort.each do |remote_name|
+        remote_url = remotes[remote_name]
         at_path { do_update |= update_remote_url(remote_name, remote_url) }
       end
     else
-      at_path { do_update |= update_remote_url(@resource.value(:remote), @resource.value(:source)) }
+      at_path { do_update |= update_remote_url(@resource.value(:remote), remotes) }
     end
 
     # If at least one remote was added or updated, then we must
@@ -178,7 +236,6 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   def update_references
     at_path do
-      update_remotes
       git_with_identity('fetch', @resource.value(:remote))
       git_with_identity('fetch', '--tags', @resource.value(:remote))
       update_owner_and_excludes
@@ -189,12 +246,17 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
 
   # @!visibility private
   def bare_git_config_exists?
-    File.exist?(File.join(@resource.value(:path), 'config'))
+    return false if not File.exist?(File.join(@resource.value(:path), 'config'))
+    begin
+      at_path { git('config', '-l', '--local') }
+      return true
+    rescue Puppet::ExecutionFailure
+      return false
+    end
   end
 
   # @!visibility private
   def clone_repository(source, path)
-    check_force
     args = ['clone']
     if @resource.value(:depth) and @resource.value(:depth).to_i > 0
       args.push('--depth', @resource.value(:depth).to_s)
@@ -225,20 +287,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   # @!visibility private
-  def check_force
-    if path_exists? and not path_empty?
-      if @resource.value(:force)
-        notice "Removing %s to replace with vcsrepo." % @resource.value(:path)
-        destroy
-      else
-        raise Puppet::Error, "Could not create repository (non-repository at path)"
-      end
-    end
-  end
-
-  # @!visibility private
-  def init_repository(path)
-    check_force
+  def init_repository
     if @resource.value(:ensure) == :bare && working_copy_exists?
       convert_working_copy_to_bare
     elsif @resource.value(:ensure) == :present && bare_exists?
@@ -283,7 +332,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
     FileUtils.mv(@resource.value(:path), tempdir)
     FileUtils.mkdir(@resource.value(:path))
     FileUtils.mv(tempdir, File.join(@resource.value(:path), '.git'))
-    if commits_in?(File.join(@resource.value(:path), '.git'))
+    if has_commits?
       reset('HEAD')
       git_with_identity('checkout', '--force')
       update_owner_and_excludes
@@ -291,11 +340,15 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   # @!visibility private
-  def commits_in?(dot_git)
-    Dir.glob(File.join(dot_git, 'objects/info/*'), File::FNM_DOTMATCH) do |e|
-      return true unless %w(. ..).include?(File::basename(e))
+  def has_commits?
+    at_path do
+      begin
+        commits = git_with_identity('rev-list', '--all', '--count').to_i
+      rescue Puppet::ExecutionFailure
+        commits = 0
+      end
+      return commits > 0
     end
-    false
   end
 
   # Will checkout a rev/branch/tag using the locally cached versions. Does not

--- a/lib/puppet/provider/vcsrepo/p4.rb
+++ b/lib/puppet/provider/vcsrepo/p4.rb
@@ -6,6 +6,7 @@ Puppet::Type.type(:vcsrepo).provide(:p4, :parent => Puppet::Provider::Vcsrepo) d
   has_features :filesystem_types, :reference_tracking, :p4config
 
   def create
+    check_force
     # create or update client
     create_client(client_name)
 
@@ -25,7 +26,7 @@ Puppet::Type.type(:vcsrepo).provide(:p4, :parent => Puppet::Provider::Vcsrepo) d
 
     # Check if workspace is setup
     args = ['where']
-    args.push(@resource.value(:path) + "...")
+    args.push(@resource.value(:path) + "/...")
     hash = p4(args, {:raise => false})
 
     return (hash['code'] != "error")
@@ -81,6 +82,18 @@ Puppet::Type.type(:vcsrepo).provide(:p4, :parent => Puppet::Provider::Vcsrepo) d
   def revision=(desired)
     sync_client(@resource.value(:source), desired)
     update_owner
+  end
+
+  def source
+    args = ['where']
+    args.push(@resource.value(:path) + "/...")
+    hash = p4(args, {:raise => false})
+
+    return hash['depotFile']
+  end
+
+  def source=(desired)
+    create # recreate
   end
 
   private

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -143,8 +143,16 @@ Puppet::Type.newtype(:vcsrepo) do
     end
   end
 
-  newparam :source do
+  newproperty :source do
     desc "The source URI for the repository"
+    # Strip tailing slashes
+    munge do |value|
+      if value[-1] == '/'
+        value[0..-2]
+      else
+        value
+      end
+    end
   end
 
   newparam :fstype, :required_features => [:filesystem_types] do
@@ -199,7 +207,7 @@ Puppet::Type.newtype(:vcsrepo) do
     desc "SSH identity file"
   end
 
-  newparam :module, :required_features => [:modules] do
+  newproperty :module, :required_features => [:modules] do
     desc "The repository module to manage"
   end
 

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -416,6 +416,11 @@ describe 'clones a remote repo' do
       it { is_expected.to be_directory }
       it { is_expected.to be_grouped_into 'testuser' }
     end
+
+    after(:all) do
+      pp = 'user { "testuser": ensure => absent }'
+      apply_manifest(pp, :catch_failures => true)
+    end
   end
 
   context 'non-origin remote name' do
@@ -436,11 +441,6 @@ describe 'clones a remote repo' do
 
     it 'remote name is "testorigin"' do
       shell("git --git-dir=#{tmpdir}/testrepo_remote/.git remote | grep 'testorigin'")
-    end
-
-    after(:all) do
-      pp = 'user { "testuser": ensure => absent }'
-      apply_manifest(pp, :catch_failures => true)
     end
   end
 

--- a/spec/acceptance/modules_1800_spec.rb
+++ b/spec/acceptance/modules_1800_spec.rb
@@ -36,6 +36,7 @@ describe 'clones a remote repo' do
       EOS
 
       apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
     end
   end
 end

--- a/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/bzr_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
+describe Puppet::Type.type(:vcsrepo).provider(:bzr) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
     :name     => 'test',
@@ -49,8 +49,9 @@ describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
   end
 
   describe "checking existence" do
-    it "should check for the directory" do
-      File.expects(:directory?).with(File.join(resource.value(:path), '.bzr')).returns(true)
+    it "should execute bzr status on the path" do
+      File.expects(:directory?).with(resource.value(:path)).returns(true)
+      provider.expects(:bzr).with('status', resource[:path])
       provider.exists?
     end
   end
@@ -106,4 +107,19 @@ describe Puppet::Type.type(:vcsrepo).provider(:bzr_provider) do
     end
   end
 
+  describe "checking the source property" do
+    it "should use 'bzr info'" do
+      expects_chdir
+      resource[:source] = 'http://bazaar.launchpad.net/~bzr-pqm/bzr/bzr.dev/'
+      provider.expects(:bzr).with('info').returns(' parent branch: http://bazaar.launchpad.net/~bzr-pqm/bzr/bzr.dev/')
+      expect(provider.source).to eq(resource.value(:source))
+    end
+  end
+  describe "setting the source property" do
+    it "should call 'create'" do
+      resource[:source] = 'http://bazaar.launchpad.net/~bzr-pqm/bzr/bzr.dev/'
+      provider.expects(:create)
+      provider.source = resource.value(:source)
+    end
+  end
 end

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
+describe Puppet::Type.type(:vcsrepo).provider(:cvs) do
 
   let(:resource) { Puppet::Type.type(:vcsrepo).new({
     :name     => 'test',
     :ensure   => :present,
     :provider => :cvs,
     :revision => '2634',
-    :source   => 'lp:do',
+    :source   => ':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs/',
     :path     => '/tmp/test',
   })}
 
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
         resource[:source] = ':ext:source@example.com:/foo/bar'
         resource[:revision] = 'an-unimportant-value'
         expects_chdir('/tmp')
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :custom_environment => {}, :combine => true)
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', '.'], :custom_environment => {}, :combine => true, :failonfail => true)
         provider.create
       end
 
@@ -32,14 +32,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
         resource[:revision] = 'an-unimportant-value'
         resource[:user] = 'muppet'
         expects_chdir('/tmp')
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', 'bar'], :uid => 'muppet', :custom_environment => {}, :combine => true)
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-r', 'an-unimportant-value', '-d', 'test', '.'], :uid => 'muppet', :custom_environment => {}, :combine => true, :failonfail => true)
         provider.create
       end
 
       it "should just execute 'cvs checkout' without a revision" do
         resource[:source] = ':ext:source@example.com:/foo/bar'
         resource.delete(:revision)
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {}, :combine => true)
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), 'checkout', '-d', File.basename(resource.value(:path)), '.'], :custom_environment => {}, :combine => true, :failonfail => true)
         provider.create
       end
 
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
           resource[:source] = ':ext:source@example.com:/foo/bar'
           resource[:compression] = '3'
           resource.delete(:revision)
-          Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), '-z', '3', 'checkout', '-d', File.basename(resource.value(:path)), File.basename(resource.value(:source))], :custom_environment => {}, :combine => true)
+          Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:source), '-z', '3', 'checkout', '-d', File.basename(resource.value(:path)), '.'], :custom_environment => {}, :combine => true, :failonfail => true)
           provider.create
         end
       end
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
     context "when a source is not given" do
       it "should execute 'cvs init'" do
         resource.delete(:source)
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:path), 'init'], :custom_environment => {}, :combine => true)
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-d', resource.value(:path), 'init'], :custom_environment => {}, :combine => true, :failonfail => true)
         provider.create
       end
     end
@@ -70,16 +70,23 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
   end
 
   describe "checking existence" do
-    it "should check for the CVS directory with source" do
-      resource[:source] = ':ext:source@example.com:/foo/bar'
-      File.expects(:directory?).with(File.join(resource.value(:path), 'CVS'))
-      provider.exists?
+    context "with a source value" do
+      it "should run 'cvs status'" do
+        resource[:source] = ':ext:source@example.com:/foo/bar'
+        File.expects(:directory?).with(File.join(resource.value(:path), 'CVS')).returns(true)
+        expects_chdir
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-nqd', resource.value(:path), 'status', '-l'], :custom_environment => {}, :combine => true, :failonfail => true)
+        provider.exists?
+      end
     end
 
-    it "should check for the CVSROOT directory without source" do
-      resource.delete(:source)
-      File.expects(:directory?).with(File.join(resource.value(:path), 'CVSROOT'))
-      provider.exists?
+    context "without a source value" do
+      it "should check for the CVSROOT directory and config file" do
+        resource.delete(:source)
+        File.expects(:directory?).with(File.join(resource.value(:path), 'CVSROOT')).returns(true)
+        File.expects(:exists?).with(File.join(resource.value(:path), 'CVSROOT', 'config,v')).returns(true)
+        provider.exists?
+      end
     end
   end
 
@@ -116,8 +123,39 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs_provider) do
 
     it "should use 'cvs update -dr'" do
       expects_chdir
-      Puppet::Util::Execution.expects(:execute).with([:cvs, 'update', '-dr', @tag, '.'], :custom_environment => {}, :combine => true)
+      Puppet::Util::Execution.expects(:execute).with([:cvs, 'update', '-dr', @tag, '.'], :custom_environment => {}, :combine => true, :failonfail => true)
       provider.revision = @tag
+    end
+  end
+
+  describe "checking the source property" do
+    it "should read the contents of file 'CVS/Root'" do
+      File.expects(:read).with(File.join(resource.value(:path), 'CVS', 'Root')).
+        returns(':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs')
+      expect(provider.source).to eq(resource.value(:source))
+    end
+  end
+  describe "setting the source property" do
+    it "should call 'create'" do
+      provider.expects(:create)
+      provider.source = resource.value(:source)
+    end
+  end
+
+  describe "checking the module property" do
+    before do
+      resource[:module] = 'ccvs'
+    end
+    it "should read the contents of file 'CVS/Repository'" do
+      File.expects(:read).with(File.join(resource.value(:path), 'CVS', 'Repository')).
+        returns('ccvs')
+      expect(provider.module).to eq(resource.value(:module))
+    end
+  end
+  describe "setting the module property" do
+    it "should call 'create'" do
+      provider.expects(:create)
+      provider.module = resource.value(:module)
     end
   end
 

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:vcsrepo).provider(:git_provider) do
+describe Puppet::Type.type(:vcsrepo).provider(:git) do
   def branch_a_list(include_branch = nil?)
     <<branches
 end
@@ -28,69 +28,95 @@ branches
   end
 
   context 'creating' do
-    context "with a revision that is a remote branch" do
-      it "should execute 'git clone' and 'git checkout -b'" do
-        resource[:revision] = 'only/remote'
-        Dir.expects(:chdir).with('/').at_least_once.yields
-        Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
-        provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
-        provider.expects(:update_submodules)
-        provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
-        provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
-        provider.expects(:git).with('checkout', '--force', resource.value(:revision))
-        provider.create
-      end
-    end
+    context "with an ensure of present" do
 
-    context "with a remote not named 'origin'" do
-      it "should execute 'git clone --origin not_origin" do
-        resource[:remote] = 'not_origin'
-        Dir.expects(:chdir).with('/').at_least_once.yields
-        Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
-        provider.expects(:git).with('clone', '--origin', 'not_origin', resource.value(:source), resource.value(:path))
-        provider.expects(:update_submodules)
-        provider.expects(:update_remote_url).with("not_origin", resource.value(:source)).returns false
-        provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
-        provider.expects(:git).with('checkout', '--force', resource.value(:revision))
-        provider.create
-      end
-    end
-
-    context "with shallow clone enable" do
-      it "should execute 'git clone --depth 1'" do
-        resource[:revision] = 'only/remote'
-        resource[:depth] = 1
-        Dir.expects(:chdir).with('/').at_least_once.yields
-        Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
-        provider.expects(:git).with('clone', '--depth', '1', '--branch', resource.value(:revision),resource.value(:source), resource.value(:path))
-        provider.expects(:update_submodules)
-        provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
-        provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
-        provider.expects(:git).with('checkout', '--force', resource.value(:revision))
-        provider.create
-      end
-    end
-
-    context "with a revision that is not a remote branch" do
-      it "should execute 'git clone' and 'git reset --hard'" do
-        resource[:revision] = 'a-commit-or-tag'
-        Dir.expects(:chdir).with('/').at_least_once.yields
-        Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
-        provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
-        provider.expects(:update_submodules)
-        provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
-        provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
-        provider.expects(:git).with('checkout', '--force', resource.value(:revision))
-        provider.create
+      context "with a revision that is a remote branch" do
+        it "should execute 'git clone' and 'git checkout -b'" do
+          resource[:revision] = 'only/remote'
+          Dir.expects(:chdir).with('/').at_least_once.yields
+          Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+          provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
+          provider.expects(:update_submodules)
+          provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
+          provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
+          provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+          provider.create
+        end
       end
 
-      it "should execute 'git clone' and submodule commands" do
-        resource.delete(:revision)
-        provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
-        provider.expects(:update_submodules)
-        provider.expects(:update_remotes)
-        provider.create
+      context "with a remote not named 'origin'" do
+        it "should execute 'git clone --origin not_origin" do
+          resource[:remote] = 'not_origin'
+          Dir.expects(:chdir).with('/').at_least_once.yields
+          Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+          provider.expects(:git).with('clone', '--origin', 'not_origin', resource.value(:source), resource.value(:path))
+          provider.expects(:update_submodules)
+          provider.expects(:update_remote_url).with("not_origin", resource.value(:source)).returns false
+          provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
+          provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+          provider.create
+        end
       end
+
+      context "with shallow clone enable" do
+        it "should execute 'git clone --depth 1'" do
+          resource[:revision] = 'only/remote'
+          resource[:depth] = 1
+          Dir.expects(:chdir).with('/').at_least_once.yields
+          Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+          provider.expects(:git).with('clone', '--depth', '1', '--branch', resource.value(:revision),resource.value(:source), resource.value(:path))
+          provider.expects(:update_submodules)
+          provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
+          provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
+          provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+          provider.create
+        end
+      end
+
+      context "with a revision that is not a remote branch" do
+        it "should execute 'git clone' and 'git reset --hard'" do
+          resource[:revision] = 'a-commit-or-tag'
+          Dir.expects(:chdir).with('/').at_least_once.yields
+          Dir.expects(:chdir).with('/tmp/test').at_least_once.yields
+          provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
+          provider.expects(:update_submodules)
+          provider.expects(:update_remote_url).with("origin", resource.value(:source)).returns false
+          provider.expects(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
+          provider.expects(:git).with('checkout', '--force', resource.value(:revision))
+          provider.create
+        end
+
+        it "should execute 'git clone' and submodule commands" do
+          resource.delete(:revision)
+          provider.expects(:git).with('clone', resource.value(:source), resource.value(:path))
+          provider.expects(:update_submodules)
+          provider.expects(:update_remotes)
+          provider.create
+        end
+      end
+
+      context "when a source is not given" do
+        context "when the path does not exist" do
+          it "should execute 'git init'" do
+            resource[:ensure] = :present
+            resource.delete(:source)
+            expects_mkdir
+            expects_chdir
+            expects_directory?(false)
+            provider.expects(:git).with('init')
+            provider.create
+          end
+        end
+
+        context "when the path is not empty and not a repository" do
+          it "should raise an exception" do
+            provider.expects(:path_exists?).returns(true)
+            provider.expects(:path_empty?).returns(false)
+            expect { provider.create }.to raise_error(Puppet::Error)
+          end
+        end
+      end
+
     end
 
     context "with an ensure of bare" do
@@ -109,9 +135,24 @@ branches
           provider.create
         end
       end
+      context "without a source" do
+        it "should execute 'git init --bare'" do
+          resource[:ensure] = :bare
+          resource.delete(:source)
+          resource.delete(:revision)
+          File.expects(:directory?).with(File.join(resource.value(:path), '.git'))
+          expects_chdir
+          expects_mkdir
+          expects_directory?(false)
+          provider.expects(:git).with('init', '--bare')
+          provider.create
+        end
+      end
+
     end
 
     context "with an ensure of mirror" do
+
       context "with revision" do
         it "should raise an error" do
           resource[:ensure] = :mirror
@@ -122,78 +163,26 @@ branches
         it "should just execute 'git clone --mirror'" do
           resource[:ensure] = :mirror
           resource.delete(:revision)
+          Dir.expects(:chdir).with('/').at_least_once.yields
           provider.expects(:git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
           provider.expects(:update_remotes)
           provider.create
         end
       end
-    end
 
-    context "when a source is not given" do
-      context "when the path does not exist" do
-        it "should execute 'git init'" do
-          resource[:ensure] = :present
+      context "without a source" do
+        it "should raise an exeption" do
+          resource[:ensure] = :mirror
           resource.delete(:source)
-          expects_mkdir
-          expects_chdir
-          expects_directory?(false)
-
-          provider.expects(:bare_exists?).returns(false)
-          provider.expects(:git).with('init')
-          provider.create
+          resource.delete(:revision)
+          expect { provider.create }.to raise_error Puppet::Error, /cannot init repository with mirror.+try bare/i
         end
       end
 
-      context "when the path is a bare repository" do
-        it "should convert it to a working copy" do
-          resource[:ensure] = :present
-          resource.delete(:source)
-          provider.expects(:bare_exists?).returns(true)
-          provider.expects(:convert_bare_to_working_copy)
-          provider.create
-        end
-      end
-
-      context "when the path is not empty and not a repository" do
-        it "should raise an exception" do
-          provider.expects(:path_exists?).returns(true)
-          provider.expects(:path_empty?).returns(false)
-          expect { provider.create }.to raise_error(Puppet::Error)
-        end
-      end
     end
 
-    context "when the path does not exist" do
-      it "should execute 'git init --bare'" do
-        resource[:ensure] = :bare
-        resource.delete(:source)
-        resource.delete(:revision)
-        expects_chdir
-        expects_mkdir
-        expects_directory?(false)
-        provider.expects(:working_copy_exists?).returns(false)
-        provider.expects(:git).with('init', '--bare')
-        provider.create
-      end
-
-      it "should raise an exeption" do
-        resource[:ensure] = :mirror
-        resource.delete(:source)
-        resource.delete(:revision)
-
-        expect { provider.create }.to raise_error Puppet::Error, /cannot init repository with mirror.+try bare/i
-      end
-    end
 
     context "when the path is a working copy repository" do
-      it "should convert it to a bare repository" do
-        resource[:ensure] = :bare
-        resource.delete(:source)
-        resource.delete(:revision)
-        provider.expects(:working_copy_exists?).returns(true)
-        provider.expects(:convert_working_copy_to_bare)
-        provider.create
-      end
       it "should clone overtop it using force" do
         resource[:force] = true
         Dir.expects(:chdir).with('/').at_least_once.yields
@@ -220,10 +209,9 @@ branches
     end
   end
 
-
   context 'destroying' do
     it "it should remove the directory" do
-      #expects_rm_rf
+      expects_rm_rf
       provider.destroy
     end
   end
@@ -244,7 +232,7 @@ branches
     context "when its SHA is not different than the current SHA" do
       it "should return the ref" do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
-        provider.expects(:update_remotes)
+        provider.expects(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end
@@ -252,7 +240,7 @@ branches
     context "when its SHA is different than the current SHA" do
       it "should return the current SHA" do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('othersha')
-        provider.expects(:update_remotes)
+        provider.expects(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end
@@ -261,7 +249,7 @@ branches
       it "should return the revision" do
         provider.stubs(:git).with('branch', '-a').returns("  remotes/origin/#{resource.value(:revision)}")
         provider.expects(:git).with('rev-parse', "origin/#{resource.value(:revision)}").returns("newsha")
-        provider.expects(:update_remotes)
+        provider.expects(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end
@@ -270,31 +258,8 @@ branches
       it "should fail" do
         provider.expects(:git).with('branch', '-a').returns(branch_a_list)
         provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('')
-        provider.expects(:update_remotes)
+        provider.expects(:update_references)
         expect { provider.revision }.to raise_error(Puppet::Error, /not a local or remote ref$/)
-      end
-    end
-
-    context "when the source is modified" do
-      it "should update the origin url" do
-        resource[:source] = 'git://git@foo.com/bar.git'
-        provider.expects(:git).with('config', '-l').returns("remote.origin.url=git://git@foo.com/foo.git\n")
-        provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
-        provider.expects(:git).with('remote','update')
-        provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
-        expect(provider.revision).to eq(resource.value(:revision))
-      end
-    end
-
-    context "when multiple sources are modified" do
-      it "should update the urls" do
-        resource[:source] = {"origin" => "git://git@foo.com/bar.git", "new_remote" => "git://git@foo.com/baz.git"}
-        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.origin.url=git://git@foo.com/bar.git\n", "remote.origin.url=git://git@foo.com/foo.git\n")
-        provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
-        provider.expects(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
-        provider.expects(:git).with('remote','update')
-        provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
-        expect(provider.revision).to eq(resource.value(:revision))
       end
     end
 
@@ -345,11 +310,100 @@ branches
     end
   end
 
+  context "checking the source property" do
+    before do
+      expects_chdir('/tmp/test')
+      provider.stubs(:git).with('config', 'remote.origin.url').returns('')
+      provider.stubs(:git).with('fetch', 'origin') # FIXME
+      provider.stubs(:git).with('fetch', '--tags', 'origin')
+      provider.stubs(:git).with('rev-parse', 'HEAD').returns('currentsha')
+      provider.stubs(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
+      provider.stubs(:git).with('tag', '-l').returns("Hello")
+    end
+
+    context "when there's a single remote 'origin'" do
+      it "should return the URL for the remote" do
+        resource[:source] = 'http://example.com'
+        provider.expects(:git).with('remote').returns("origin\n")
+        provider.expects(:git).with('config', '--get', 'remote.origin.url').returns('http://example.com')
+        expect(provider.source).to eq(resource.value(:source))
+      end
+    end
+
+    context "when there's more than one remote" do
+      it "should return the remotes as a hash" do
+        resource[:source] = {"origin" => "git://git@foo.com/bar.git", "other" => "git://git@foo.com/baz.git"}
+        provider.expects(:git).with('remote').returns("origin\nother\n")
+        provider.expects(:git).with('config', '--get', 'remote.origin.url').returns('git://git@foo.com/bar.git')
+        provider.expects(:git).with('config', '--get', 'remote.other.url').returns('git://git@foo.com/baz.git')
+        expect(provider.source).to eq(resource.value(:source))
+      end
+    end
+  end
+
+  context "updating remotes" do
+
+    context "from string to string" do
+      it "should fail" do
+        resource[:source] = 'git://git@foo.com/bar.git'
+        resource[:force] = false
+
+        provider.expects(:source).returns('git://git@foo.com/foo.git')
+        provider.expects(:path_exists?).returns(true)
+        provider.expects(:path_empty?).returns(false)
+        expect { provider.source = resource.value(:source) }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context "from hash to hash" do
+      it "should add any new remotes, update any existing remotes, remove deleted remotes" do
+        expects_chdir
+        resource[:source] = {"origin" => "git://git@foo.com/bar.git", "new_remote" => "git://git@foo.com/baz.git"}
+        provider.expects(:source).returns(
+          {'origin' => 'git://git@foo.com/foo.git',
+           'old_remote' => 'git://git@foo.com/old.git'})
+        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.old_remote.url=git://git@foo.com/old.git\n", "remote.origin.url=git://git@foo.com/foo.git\n")
+        provider.expects(:git).with('remote', 'remove', 'old_remote')
+        provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
+        provider.expects(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
+        provider.expects(:git).with('remote','update')
+        provider.source = resource.value(:source)
+      end
+    end
+
+    context "from string to hash" do
+      it "should add any new remotes, update origin remote" do
+        expects_chdir
+        resource[:source] = {"origin" => "git://git@foo.com/bar.git", "new_remote" => "git://git@foo.com/baz.git"}
+        provider.expects(:source).returns('git://git@foo.com/foo.git')
+        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.origin.url=git://git@foo.com/foo.git\n")
+        provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
+        provider.expects(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
+        provider.expects(:git).with('remote','update')
+        provider.source = resource.value(:source)
+      end
+    end
+
+    context "from hash to string" do
+      it "should update origin remote, remove deleted remotes" do
+        expects_chdir
+        resource[:source] = "git://git@foo.com/baz.git"
+        provider.expects(:source).returns(
+          {'origin' => 'git://git@foo.com/foo.git',
+           'old_remote' => 'git://git@foo.com/old.git'})
+        provider.expects(:git).with('remote', 'remove', 'old_remote')
+        provider.expects(:git).at_least_once.with('config', '-l').returns("remote.origin.url=git://git@foo.com/foo.git\n", "remote.other.url=git://git@foo.com/bar.git\n")
+        provider.expects(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/baz.git')
+        provider.expects(:git).with('remote','update')
+        provider.source = resource.value(:source)
+      end
+    end
+  end
+
   context "updating references" do
     it "should use 'git fetch --tags'" do
       resource.delete(:source)
       expects_chdir
-      provider.expects(:git).with('config', '-l').returns("remote.origin.url=git://git@foo.com/foo.git\n")
       provider.expects(:git).with('fetch', 'origin')
       provider.expects(:git).with('fetch', '--tags', 'origin')
       provider.update_references
@@ -388,7 +442,7 @@ branches
       FileUtils.expects(:mv).returns(true)
       FileUtils.expects(:mkdir).returns(true)
       FileUtils.expects(:mv).returns(true)
-      provider.expects(:commits_in?).returns(true)
+      provider.expects(:has_commits?).returns(true)
       # If you forget to stub these out you lose 3 hours of rspec work.
       provider.expects(:reset).with('HEAD').returns(true)
       provider.expects(:git_with_identity).returns(true)

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -69,7 +69,8 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
 
   describe "checking existence" do
     it "should check for the directory" do
-      expects_directory?(true, File.join(resource.value(:path), '.hg'))
+      expects_directory?(true, resource.value(:path))
+      provider.expects(:hg).with('status', resource.value(:path))
       provider.exists?
     end
   end
@@ -132,6 +133,23 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
       provider.expects(:hg).with('merge')
       provider.expects(:hg).with('update', '--clean', '-r', @revision)
       provider.revision = @revision
+    end
+  end
+
+  describe "checking the source property" do
+    it "should return the default path" do
+      resource[:source] = 'http://selenic.com/hg'
+      expects_chdir
+      provider.expects(:hg_wrapper).with('paths').returns('default = http://selenic.com/hg')
+      expect(provider.source).to eq(resource.value(:source))
+    end
+  end
+
+  describe "setting the source property" do
+    it "should call 'create'" do
+      resource[:source] = 'some-example'
+      provider.expects(:create)
+      provider.source = resource.value(:source)
     end
   end
 

--- a/spec/unit/puppet/provider/vcsrepo/p4_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/p4_spec.rb
@@ -74,8 +74,27 @@ describe Puppet::Type.type(:vcsrepo).provider(:p4) do
   describe "checking existence" do
     it "should check for the directory" do
       provider.expects(:p4).with(['info'], {:marshal => false}).returns({})
-      provider.expects(:p4).with(['where', resource.value(:path) + "..."], {:raise => false}).returns({})
+      provider.expects(:p4).with(['where', resource.value(:path) + "/..."], {:raise => false}).returns({})
       provider.exists?
+    end
+  end
+
+  describe "checking the source property" do
+    it "should run 'p4 where'" do
+      resource[:source] = '//public/something'
+      provider.expects(:p4).with(['where', resource.value(:path) + '/...'],
+                                 {:raise => false}).returns({
+                                   'depotFile' => '//public/something'
+                                 })
+      expect(provider.source).to eq(resource.value(:source))
+    end
+  end
+
+  describe "setting the source property" do
+    it "should call 'create'" do
+      resource[:source] = '//public/something'
+      provider.expects(:create)
+      provider.source = resource.value(:source)
     end
   end
 

--- a/spec/unit/puppet/type/vcsrepo_spec.rb
+++ b/spec/unit/puppet/type/vcsrepo_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:vcsrepo) do
     resource.property(:ensure)
   end
 
-  properties = [ :ensure ]
+  properties = [ :ensure, :source ]
 
   properties.each do |property|
     it "should have a #{property} property" do
@@ -46,6 +46,13 @@ describe Puppet::Type.type(:vcsrepo) do
   parameters.each do |parameter|
     it "should have a #{parameter} parameter" do
       expect(described_class.attrclass(parameter).ancestors).to be_include(Puppet::Parameter)
+    end
+  end
+
+  describe "munging of 'source' property" do
+    it "should remove trailing /" do
+      resource[:source] = ':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs/'
+      expect(resource[:source]).to eq(':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs')
     end
   end
 


### PR DESCRIPTION
Changes common to all providers:
- `:source` is now a property
- `check_force` moved from git provider to base vcsrepo provider
- `check_force` added to every provider's create method
- use provider binary for `exists?` (not just directory check*)

Changes to specific providers:
- bzr
  - `source` returns the `parent branch` as output by `bzr info`
  - changing `:source` calls `provider.create`
- cvs
  - (*) init'd repos make `cvs status` error, so it still relies on
    file/directory checks. That is, from what I can tell.
  - module properly handles checkout paths now
  - `source` returns the contents of file `<path>/CVS/Root`
  - changing `:source` calls `provider.create`
  - `:module` is now a property
  - `module` returns the contents of file `<path>/CVS/Repository`
  - changing `:module` calls `provider.create`
- git
  - `source` returns the url for the remote, or a hash of `{remote_name
    => remote_url}` if multiple remotes are found in the git config
  - changing `:source` from string to string calls `create`
  - changing `:source` in all other cases modifies the repo's remotes
  - many changes to git calls for more robustness
- hg
  - `source` returns the `default` path from `hg paths`
  - changing `:source` calls `provider.create`
- p4
  - `source` returns the `depotFile` returned by `p4 where <path>/...`
  - changing `:source` calls `provider.create`
- svn
  - `source` returns the `URL` grepped from `svn info`
  - changing `:source` calls `svn switch <new_source>`

Notes/Problems:
- I have no idea how bazaar works. Is it possible to switch branches
  a-la `svn switch`? How do you reliably track the source? Someone might
  have to lend a hand here, as the value returned by bzr's `source` is
  the "302"'d source, not, for instance, `lp:bzr`.
- I think I got the perforce right, but I'm not sure.