### PR TITLE
"Better" handling of :ensure changes

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -531,4 +531,58 @@ describe 'clones a remote repo' do
       apply_manifest(pp, :catch_changes => true)
     end
   end
+
+  context 'bare repo' do
+    it 'creates a bare repo' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/testrepo_bare_repo":
+        ensure => bare,
+        provider => git,
+        source => "file://#{tmpdir}/testrepo.git",
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/testrepo_bare_repo/config") do
+      it { is_expected.to contain 'bare = true' }
+    end
+    describe file("#{tmpdir}/testrepo_bare_repo/.git") do
+      it { is_expected.not_to be_directory }
+    end
+    describe file("#{tmpdir}/testrepo_bare_repo/HEAD") do
+      it { is_expected.to contain 'ref: refs/heads/master' }
+    end
+  end
+
+  context 'mirror repo' do
+    it 'creates a mirror repo' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/testrepo_mirror_repo":
+        ensure => mirror,
+        provider => git,
+        source => "file://#{tmpdir}/testrepo.git",
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/testrepo_mirror_repo/config") do
+      it { is_expected.to contain 'bare = true' }
+      it { is_expected.to contain 'mirror = true' }
+    end
+    describe file("#{tmpdir}/testrepo_mirror_repo/.git") do
+      it { is_expected.not_to be_directory }
+    end
+    describe file("#{tmpdir}/testrepo_mirror_repo/HEAD") do
+      it { is_expected.to contain 'ref: refs/heads/master' }
+    end
+  end
+
 end

--- a/spec/acceptance/create_repo_spec.rb
+++ b/spec/acceptance/create_repo_spec.rb
@@ -86,4 +86,22 @@ describe 'create a repo' do
       it { is_expected.not_to be_directory }
     end
   end
+
+  context 'mirror repo' do
+    it 'does not create a mirror repo' do
+      pp = <<-EOS
+      vcsrepo { "#{tmpdir}/testrepo_mirror_repo":
+        ensure => mirror,
+        provider => git,
+      }
+      EOS
+
+      apply_manifest(pp, :expect_failures => true)
+    end
+
+    describe file("#{tmpdir}/testrepo_mirror_repo") do
+      it { is_expected.not_to be_directory }
+    end
+  end
+
 end


### PR DESCRIPTION
Currently the git provider handles changes between :bare/:mirror and
:present/:latest inside its checkout and init calls. That's a bit silly,
so I moved the logic inside the ensurable block. Now when you change the
ensure type it will show the proper "ensure changed" notice.

This meant I had to pull the conversion functions up from the private
section of the methods to the public.

I also fixed up some of the code to be more robust. It now sets mirror
properties and all that.