### PR TITLE
[MODULES-3998] Fix issue where older git versions dont support git config's '--local' param

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -340,7 +340,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def bare_git_config_exists?
     return false if not File.exist?(File.join(@resource.value(:path), 'config'))
     begin
-      at_path { git('config', '-l', '--local') }
+      at_path { git('config', '--list', '--file', 'config') }
       return true
     rescue Puppet::ExecutionFailure
       return false


### PR DESCRIPTION
This fixes an issue that was discovered in RHEL6 based distros where git <= v1.7.10 do not support git config '--local' param. This functionality was only added in git 1.7.11. This meant that when the bare_git_config_exists? function was called, an error was thrown.

This appeared on RHEL6 as the latest git version in the yum repo is 1.7.1.

The fix is to use git config --file and point the the bare repo's config file when checking for the existence of a bare_repo.