### PR TITLE
[MODULES-3998] Fix issues with older versions of GIT and SVN

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -521,7 +521,9 @@ vcsrepo { '/path/to/repo':
 
 ####Checking out only specific paths
 
-You can check out only specific paths in a particular repository by providing their relative paths to the `include` parameter, like so:
+**Note:** The `includes` param is only supported when subversion client version is >= 1.7.
+
+You can check out only specific paths in a particular repository by providing their relative paths to the `includes` parameter, like so:
 
 ~~~
 vcsrepo { '/path/to/repo':
@@ -803,7 +805,7 @@ Specifies a source repository to serve as the upstream for your managed reposito
 * `cvs` - A string containing a CVS root.
 * `hg` - A string containing the local path or URL of a Mercurial repository.
 * `p4` - A string containing a Perforce depot path.
-* `svn` - A string containing a Subversion repository URL.
+* `svn` - A string containing a Subversion repository URL, without trailing slash.
 
 Default: none.
 
@@ -822,6 +824,8 @@ Specifies the user to run as for repository operations. (Requires the `user` fea
 ## Limitations
 
 Git is the only VCS provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
+
+The includes parameter is only supported when SVN client version is >= 1.7
 
 This module has been tested with Puppet 2.7 and higher.
 

--- a/lib/facter/vcsrepo_svn_version.rb
+++ b/lib/facter/vcsrepo_svn_version.rb
@@ -1,0 +1,7 @@
+Facter.add(:vcsrepo_svn_version) do
+  setcode do
+    res = Facter::Core::Execution.execute('svn --version --quiet')
+    return nil if res =~ /command not found/
+    return res;
+  end
+end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -340,7 +340,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def bare_git_config_exists?
     return false if not File.exist?(File.join(@resource.value(:path), 'config'))
     begin
-      at_path { git('config', '-l', '--local') }
+      at_path { git('config', '--list', '--file', 'config') }
       return true
     rescue Puppet::ExecutionFailure
       return false

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -220,6 +220,12 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def update_includes(paths)
+    #If svn version < 1.7, '--parents' isn't supported. Raise legible error.
+    svn_ver = get_svn_client_version
+    if svn_ver == nil || Gem::Version.new(svn_ver) < Gem::Version.new('1.7')
+      raise "Includes option is not available for SVN versions < 1.7. Version installed: #{svn_ver}"
+    end
+
     at_path do
       args = buildargs.push('update')
       if @resource.value(:revision)
@@ -232,6 +238,12 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
       args.push(*paths)
       svn(*args)
     end
+  end
+
+  def get_svn_client_version
+    ver = Facter.value(:vcsrepo_svn_version)
+    return '0.0' if ver == nil
+    return ver;
   end
 
 end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -166,14 +166,6 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newproperty :source do
     desc "The source URI for the repository"
-    # Strip tailing slashes
-    munge do |value|
-      if value[-1] == '/'
-        value[0..-2]
-      else
-        value
-      end
-    end
   end
 
   newparam :fstype, :required_features => [:filesystem_types] do

--- a/spec/acceptance/svn_paths_spec.rb
+++ b/spec/acceptance/svn_paths_spec.rb
@@ -12,125 +12,129 @@ describe 'subversion :includes tests' do
     shell("rm -rf #{tmpdir}/svnrepo")
   end
 
-  context "include paths" do
-    it "can checkout specific paths from svn" do
-      pp = <<-EOS
+  svn_ver = fact('vcsrepo_svn_version')
+  if svn_ver != nil && Gem::Version.new(svn_ver) >= Gem::Version.new('1.7')
+
+    context "include paths" do
+      it "can checkout specific paths from svn" do
+        pp = <<-EOS
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
         includes => ['difftools/README', 'obsolete-notes',],
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1000000,
       }
-      EOS
+        EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{tmpdir}/svnrepo/difftools") do
+        it { should be_directory }
+      end
+      describe file("#{tmpdir}/svnrepo/difftools/README") do
+        its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+      end
+      describe file("#{tmpdir}/svnrepo/difftools/pics") do
+        it { should_not exist }
+      end
+      describe file("#{tmpdir}/svnrepo/obsolete-notes") do
+        it { should be_directory }
+      end
+      describe file("#{tmpdir}/svnrepo/obsolete-notes/draft-korn-vcdiff-01.txt") do
+        its(:md5sum) { should eq '37019f808e1af64864853a67526cfe19' }
+      end
+      describe file("#{tmpdir}/svnrepo/obsolete-notes/vcdiff-karlnotes") do
+        its(:md5sum) { should eq '26e23ff6a156de14aebd1099e23ac2d8' }
+      end
+      describe file("#{tmpdir}/svnrepo/guis") do
+        it { should_not exist }
+      end
     end
 
-    describe file("#{tmpdir}/svnrepo/difftools") do
-      it { should be_directory }
-    end
-    describe file("#{tmpdir}/svnrepo/difftools/README") do
-      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
-    end
-    describe file("#{tmpdir}/svnrepo/difftools/pics") do
-      it { should_not exist }
-    end
-    describe file("#{tmpdir}/svnrepo/obsolete-notes") do
-      it { should be_directory }
-    end
-    describe file("#{tmpdir}/svnrepo/obsolete-notes/draft-korn-vcdiff-01.txt") do
-      its(:md5sum) { should eq '37019f808e1af64864853a67526cfe19' }
-    end
-    describe file("#{tmpdir}/svnrepo/obsolete-notes/vcdiff-karlnotes") do
-      its(:md5sum) { should eq '26e23ff6a156de14aebd1099e23ac2d8' }
-    end
-    describe file("#{tmpdir}/svnrepo/guis") do
-      it { should_not exist }
-    end
-  end
-
-  context "add include paths" do
-    it "can add paths to includes" do
-      pp = <<-EOS
+    context "add include paths" do
+      it "can add paths to includes" do
+        pp = <<-EOS
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
         includes => ['difftools/README', 'obsolete-notes', 'guis/pics/README', 'difftools/pics/README'],
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1000000,
       }
-      EOS
+        EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+        its(:md5sum) { should eq '62bdc9180684042fe764d89c9beda40f' }
+      end
+      describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+        its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
+      end
     end
 
-    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
-      its(:md5sum) { should eq '62bdc9180684042fe764d89c9beda40f' }
-    end
-    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
-      its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
-    end
-  end
-
-  context "remove include paths" do
-    it "can remove paths (and empty parent directories) from includes" do
-      pp = <<-EOS
+    context "remove include paths" do
+      it "can remove paths (and empty parent directories) from includes" do
+        pp = <<-EOS
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
         includes => ['difftools/README', 'obsolete-notes',],
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1000000,
       }
-      EOS
+        EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+        it { should_not exist }
+      end
+      describe file("#{tmpdir}/svnrepo/guis") do
+        it { should_not exist }
+      end
+      describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+        it { should_not exist }
+      end
+      describe file("#{tmpdir}/svnrepo/difftools/README") do
+        its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+      end
     end
 
-    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
-      it { should_not exist }
-    end
-    describe file("#{tmpdir}/svnrepo/guis") do
-      it { should_not exist }
-    end
-    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
-      it { should_not exist }
-    end
-    describe file("#{tmpdir}/svnrepo/difftools/README") do
-      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
-    end
-  end
-
-  context "changing revisions" do
-    it "can change revisions" do
-      pp = <<-EOS
+    context "changing revisions" do
+      it "can change revisions" do
+        pp = <<-EOS
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
         includes => ['difftools/README', 'obsolete-notes',],
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1700000,
       }
-      EOS
+        EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe command("svn info #{tmpdir}/svnrepo") do
+        its(:stdout) { should match(/.*Revision: 1700000.*/) }
+      end
+      describe command("svn info #{tmpdir}/svnrepo/difftools/README") do
+        its(:stdout) { should match(/.*Revision: 1700000.*/) }
+      end
     end
 
-    describe command("svn info #{tmpdir}/svnrepo") do
-      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
-    end
-    describe command("svn info #{tmpdir}/svnrepo/difftools/README") do
-      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
-    end
   end
-
 end

--- a/spec/acceptance/svn_spec.rb
+++ b/spec/acceptance/svn_spec.rb
@@ -13,7 +13,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/svn-logos/",
+        source   => "http://svn.apache.org/repos/asf/subversion/svn-logos",
       }
       EOS
 
@@ -42,7 +42,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1000000,
       }
       EOS
@@ -71,7 +71,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1700000,
       }
       EOS
@@ -101,7 +101,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.0/",
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.0",
       }
       EOS
       # Run it twice and test for idempotency
@@ -122,7 +122,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.4/",
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.4",
       }
       EOS
       # Run it twice and test for idempotency


### PR DESCRIPTION
This fixes 2 issues that was discovered in RHEL6 based distros when git <= v1.7.10 do not support git config '--local' param and svn < 1.7 does not support the svn update --parents parameter. 

1. Git Issue: 
git config's '--local' parameter functionality was only added in git 1.7.11. This meant that when the bare_git_config_exists? function was called, an error was thrown. This appeared on RHEL6 as the latest git version in the yum repo is 1.7.1. The fix is to use git config --file and point the the bare repo's config file when checking for the existence of a bare_repo.

2. SVN Issue:
svn update's '--parents' parameter wasn't supported until SVN version 1.7. Meaning on older versions of SVN the includes option would fail. This is now handled appropriately in the module, the README and in the tests.