### PR TITLE
[MODULES-3998] Fix to GIT and SVN providers to support older versions of git and svn

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -521,7 +521,9 @@ vcsrepo { '/path/to/repo':
 
 ####Checking out only specific paths
 
-You can check out only specific paths in a particular repository by providing their relative paths to the `include` parameter, like so:
+**Note:** The `includes` param is only supported when subversion client version is >= 1.7.
+
+You can check out only specific paths in a particular repository by providing their relative paths to the `includes` parameter, like so:
 
 ~~~
 vcsrepo { '/path/to/repo':
@@ -803,7 +805,7 @@ Specifies a source repository to serve as the upstream for your managed reposito
 * `cvs` - A string containing a CVS root.
 * `hg` - A string containing the local path or URL of a Mercurial repository.
 * `p4` - A string containing a Perforce depot path.
-* `svn` - A string containing a Subversion repository URL.
+* `svn` - A string containing a Subversion repository URL, without trailing slash.
 
 Default: none.
 
@@ -822,6 +824,8 @@ Specifies the user to run as for repository operations. (Requires the `user` fea
 ## Limitations
 
 Git is the only VCS provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
+
+The includes parameter is only supported when SVN client version is >= 1.7
 
 This module has been tested with Puppet 2.7 and higher.
 

--- a/lib/facter/vcsrepo_svn_ver.rb
+++ b/lib/facter/vcsrepo_svn_ver.rb
@@ -1,0 +1,14 @@
+Facter.add(:vcsrepo_svn_ver) do
+  setcode do
+    begin
+      version = Facter::Core::Execution.execute('svn --version --quiet')
+      if Gem::Version.new(version) > Gem::Version.new('0.0.1')
+        version
+      else
+        ''
+      end
+    rescue
+      ''
+    end
+  end
+end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -340,7 +340,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, :parent => Puppet::Provider::Vcsrepo) 
   def bare_git_config_exists?
     return false if not File.exist?(File.join(@resource.value(:path), 'config'))
     begin
-      at_path { git('config', '-l', '--local') }
+      at_path { git('config', '--list', '--file', 'config') }
       return true
     rescue Puppet::ExecutionFailure
       return false

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -220,6 +220,11 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
   end
 
   def update_includes(paths)
+    #If svn version < 1.7, '--parents' isn't supported. Raise legible error.
+    svn_ver = get_svn_client_version
+    if Gem::Version.new(svn_ver) < Gem::Version.new('1.7.0')
+      raise "Includes option is not available for SVN versions < 1.7. Version installed: #{svn_ver}"
+    end
     at_path do
       args = buildargs.push('update')
       if @resource.value(:revision)
@@ -234,4 +239,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
     end
   end
 
+  def get_svn_client_version
+    return Facter.value('vcsrepo_svn_ver')
+  end
 end

--- a/spec/acceptance/svn_spec.rb
+++ b/spec/acceptance/svn_spec.rb
@@ -13,7 +13,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/svn-logos/",
+        source   => "http://svn.apache.org/repos/asf/subversion/svn-logos",
       }
       EOS
 
@@ -42,7 +42,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1000000,
       }
       EOS
@@ -71,7 +71,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources/",
+        source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
         revision => 1700000,
       }
       EOS
@@ -101,7 +101,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.0/",
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.0",
       }
       EOS
       # Run it twice and test for idempotency
@@ -122,7 +122,7 @@ describe 'subversion tests' do
       vcsrepo { "#{tmpdir}/svnrepo":
         ensure   => present,
         provider => svn,
-        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.4/",
+        source   => "http://svn.apache.org/repos/asf/subversion/tags/1.9.4",
       }
       EOS
       # Run it twice and test for idempotency

--- a/spec/unit/facter/vcsrepo_svn_ver_spec.rb
+++ b/spec/unit/facter/vcsrepo_svn_ver_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe "vcsrepo_svn_ver" do
+    context 'with valid value' do
+      before :each do
+        Facter::Core::Execution
+            .stubs(:execute)
+            .with('svn --version --quiet')
+            .returns('1.7.23')
+      end
+      it {
+        expect(Facter.fact(:vcsrepo_svn_ver).value).to eq('1.7.23')
+      }
+    end
+  end
+end


### PR DESCRIPTION
Fix to git provider on older git versions where git config --local param not supported. Update SVN provider to remove Includes option support from SVN versions < 1.7 and update tests and README to reflect this.

These issues were picked up on RHEL6 based distros as they use older versions of git and svn.