### PR TITLE
Better management of '/'s for :source and :includes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -805,7 +805,7 @@ Specifies a source repository to serve as the upstream for your managed reposito
 * `cvs` - A string containing a CVS root.
 * `hg` - A string containing the local path or URL of a Mercurial repository.
 * `p4` - A string containing a Perforce depot path.
-* `svn` - A string containing a Subversion repository URL, without trailing slash.
+* `svn` - A string containing a Subversion repository URL.
 
 Default: none.
 

--- a/lib/puppet/provider/vcsrepo/bzr.rb
+++ b/lib/puppet/provider/vcsrepo/bzr.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:vcsrepo).provide(:bzr, :parent => Puppet::Provider::Vcsrepo) 
 
   def source
     at_path do
-      bzr('info')[/^\s+parent branch:\s+(\S+?)\/?$/m, 1]
+      bzr('info')[/^\s+parent branch:\s+(\S+?)$/m, 1]
     end
   end
 

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -131,7 +131,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs) do
   describe "checking the source property" do
     it "should read the contents of file 'CVS/Root'" do
       File.expects(:read).with(File.join(resource.value(:path), 'CVS', 'Root')).
-        returns(':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs')
+        returns(':pserver:anonymous@cvs.sv.gnu.org:/sources/cvs/')
       expect(provider.source).to eq(resource.value(:source))
     end
   end


### PR DESCRIPTION
I don't know why I didn't realize that `insync?` was the smarter way to
get around `/` munging by providers. But I did, so there.

Also, it now errors when an include path starts with a `/`.

Removing @wilson208's "without trailing slash" from README since it's
no longer needed.