### PR TITLE
Make :includes work with svn 1.6

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -521,7 +521,7 @@ vcsrepo { '/path/to/repo':
 
 ####Checking out only specific paths
 
-**Note:** The `includes` param is only supported when subversion client version is >= 1.7.
+**Note:** The `includes` param is only supported when subversion client version is >= 1.6.
 
 You can check out only specific paths in a particular repository by providing their relative paths to the `includes` parameter, like so:
 
@@ -679,7 +679,7 @@ Parameters: `ensure`, `excludes`, `force`, `group`, `owner`, `p4config`, `path`,
 
 Features: `basic_auth`, `configuration`, `conflict`, `depth`, `filesystem_types`, `reference_tracking`
 
-Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conflict`, `ensure`, `excludes`, `force`, `fstype`, `group`, `owner`, `path`, `provider`, `revision`, `source`, `trust_server_cert`
+Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conflict`, `ensure`, `excludes`, `force`, `fstype`, `group`, `includes`, `owner`, `path`, `provider`, `revision`, `source`, `trust_server_cert`
 
 #### Features
 
@@ -693,6 +693,7 @@ Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conf
 * `depth` - Supports shallow clones in `git` or sets the scope limit in `svn`. (Available with `git` and `svn`.)
 * `filesystem_types` - Supports multiple types of filesystem. (Available with `svn`.)
 * `gzip_compression` - Supports explicit GZip compression levels. (Available with `cvs`.)
+* `include_paths` - Lets you checkout only certain paths. (Available with `svn`.)
 * `modules` - Lets you choose a specific repository module. (Available with `cvs`.)
 * `multiple_remotes` - Tracks multiple remote repositories. (Available with `git`.)
 * `reference_tracking` - Lets you track revision references that can change over time (e.g., some VCS tags and branch names). (Available with all providers)
@@ -758,6 +759,10 @@ Specifies a group to own the repository files. Valid options: a string containin
 ##### `identity`
 
 Specifies an identity file to use for SSH authentication. (Requires the `ssh_identity` feature.) Valid options: a string containing an absolute path. Default: none.
+
+##### `includes`
+
+Tells Subversion which paths should be checked out at the specified depth; all other paths are not checked out. Default: none (checkout all paths).
 
 ##### `module`
 
@@ -825,7 +830,7 @@ Specifies the user to run as for repository operations. (Requires the `user` fea
 
 Git is the only VCS provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
 
-The includes parameter is only supported when SVN client version is >= 1.7
+The includes parameter is only supported when SVN client version is >= 1.6.
 
 This module has been tested with Puppet 2.7 and higher.
 

--- a/spec/acceptance/svn_paths_spec.rb
+++ b/spec/acceptance/svn_paths_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper_acceptance'
 
 tmpdir = default.tmpdir('vcsrepo')
 
-describe 'subversion :includes tests on SVN version > 1.7', :unless =>
-    (fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') =~ /(5|6)/) do
+describe 'subversion :includes tests on SVN version >= 1.7', :unless => (
+    (fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') =~ /(5|6)/) or
+    (fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') =~ /(6|7|10.04|12.04)/) or
+    (fact('osfamily') == 'SLES')
+) do
 
   before(:all) do
     shell("mkdir -p #{tmpdir}") # win test
@@ -59,7 +62,7 @@ describe 'subversion :includes tests on SVN version > 1.7', :unless =>
         vcsrepo { "#{tmpdir}/svnrepo":
           ensure   => present,
           provider => svn,
-          includes => ['difftools/README', 'obsolete-notes', 'guis/pics/README', 'difftools/pics/README'],
+          includes => ['difftools/README', 'obsolete-notes', 'guis/pics', 'difftools/pics/README'],
           source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
           revision => 1000000,
         }
@@ -84,7 +87,7 @@ describe 'subversion :includes tests on SVN version > 1.7', :unless =>
         vcsrepo { "#{tmpdir}/svnrepo":
           ensure   => present,
           provider => svn,
-          includes => ['difftools/README', 'obsolete-notes',],
+          includes => ['difftools/pics/README', 'obsolete-notes',],
           source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
           revision => 1000000,
         }
@@ -98,11 +101,147 @@ describe 'subversion :includes tests on SVN version > 1.7', :unless =>
     describe file("#{tmpdir}/svnrepo/guis/pics/README") do
       it { should_not exist }
     end
+    describe file("#{tmpdir}/svnrepo/guis/pics") do
+      it { should_not exist }
+    end
     describe file("#{tmpdir}/svnrepo/guis") do
       it { should_not exist }
     end
     describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+      its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/README") do
       it { should_not exist }
+    end
+  end
+
+  context "changing revisions" do
+    it "can change revisions" do
+      pp = <<-EOS
+        vcsrepo { "#{tmpdir}/svnrepo":
+          ensure   => present,
+          provider => svn,
+          includes => ['difftools/README', 'obsolete-notes',],
+          source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
+          revision => 1700000,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe command("svn info #{tmpdir}/svnrepo") do
+      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
+    end
+    describe command("svn info #{tmpdir}/svnrepo/difftools/README") do
+      its(:stdout) { should match( /.*Revision: 1700000.*/ ) }
+    end
+  end
+end
+
+describe 'subversion :includes tests on SVN version == 1.6', :if => (
+    (fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') =~ /(5|6)/) or
+    (fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') =~ /(6|7|10.04|12.04)/)
+) do
+
+  after(:all) do
+    shell("rm -rf #{tmpdir}/svnrepo")
+  end
+
+  context "include paths" do
+    it "can checkout specific paths from svn" do
+      pp = <<-EOS
+        vcsrepo { "#{tmpdir}/svnrepo":
+          ensure   => present,
+          provider => svn,
+          includes => ['difftools/README', 'obsolete-notes',],
+          source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
+          revision => 1000000,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/difftools") do
+      it { should be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/README") do
+      its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes") do
+      it { should be_directory }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes/draft-korn-vcdiff-01.txt") do
+      its(:md5sum) { should eq '37019f808e1af64864853a67526cfe19' }
+    end
+    describe file("#{tmpdir}/svnrepo/obsolete-notes/vcdiff-karlnotes") do
+      its(:md5sum) { should eq '26e23ff6a156de14aebd1099e23ac2d8' }
+    end
+    describe file("#{tmpdir}/svnrepo/guis") do
+      it { should_not exist }
+    end
+  end
+
+  context "add include paths" do
+    it "can add paths to includes" do
+      pp = <<-EOS
+        vcsrepo { "#{tmpdir}/svnrepo":
+          ensure   => present,
+          provider => svn,
+          includes => ['difftools/README', 'obsolete-notes', 'guis/pics', 'difftools/pics/README'],
+          source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
+          revision => 1000000,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+      its(:md5sum) { should eq '62bdc9180684042fe764d89c9beda40f' }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+      its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
+    end
+  end
+
+  context "remove include paths" do
+    it "can remove directory paths (and empty parent directories) from includes, but not files with siblings" do
+      pp = <<-EOS
+        vcsrepo { "#{tmpdir}/svnrepo":
+          ensure   => present,
+          provider => svn,
+          includes => ['difftools/pics/README', 'obsolete-notes',],
+          source   => "http://svn.apache.org/repos/asf/subversion/developer-resources",
+          revision => 1000000,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{tmpdir}/svnrepo/guis/pics/README") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/guis/pics") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/guis") do
+      it { should_not exist }
+    end
+    describe file("#{tmpdir}/svnrepo/difftools/pics/README") do
+      its(:md5sum) { should eq 'bad02dfc3cb96bf5cadd59bf4fe3e00e' }
     end
     describe file("#{tmpdir}/svnrepo/difftools/README") do
       its(:md5sum) { should eq '540241e9d5d4740d0ef3d27c3074cf93' }
@@ -135,11 +274,11 @@ describe 'subversion :includes tests on SVN version > 1.7', :unless =>
   end
 end
 
-describe 'subversion :includes tests on SVN version < 1.7', :if =>
-    (fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') =~ /(5|6)/) do
+describe 'subversion :includes tests on SVN version < 1.6', :if =>
+    (fact('osfamily') == 'SLES') do
 
   context "include paths" do
-    it "fails when SVN version < 1.7" do
+    it "fails when SVN version < 1.6" do
       pp = <<-EOS
         vcsrepo { "#{tmpdir}/svnrepo":
           ensure   => present,
@@ -150,9 +289,9 @@ describe 'subversion :includes tests on SVN version < 1.7', :if =>
         }
       EOS
 
-      # Expect error when svn < 1.7 and includes is used
+      # Expect error when svn < 1.6 and includes is used
       apply_manifest(pp, :expect_failures => true) do |r|
-        expect(r.stderr).to match /Includes option is not available for SVN versions < 1.7. Version installed:/
+        expect(r.stderr).to match(/Includes option is not available for SVN versions < 1.6. Version installed:/)
       end
     end
   end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
   let(:provider) { resource.provider }
 
   let(:test_paths) { ['path1/file1', 'path2/nested/deep/file2'] }
+  let(:test_paths_parents) { ['path1', 'path2', 'path2/nested', 'path2/nested/deep'] }
 
   before :each do
     Puppet::Util.stubs(:which).with('svn').returns('/usr/bin/svn')
@@ -99,7 +100,9 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         provider.expects(:svn).with('--non-interactive', 'checkout', '--depth', 'empty',
           resource.value(:source),
           resource.value(:path))
-        provider.expects(:svn).with('--non-interactive', 'update', '--parents',
+        provider.expects(:svn).with('--non-interactive', 'update', '--depth', 'empty',
+          *test_paths_parents)
+        provider.expects(:svn).with('--non-interactive', 'update',
           *resource[:includes])
         provider.create
       end
@@ -113,9 +116,12 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
           '--depth', 'empty',
           resource.value(:source),
           resource.value(:path))
+        provider.expects(:svn).with('--non-interactive', 'update', 
+          '--depth', 'empty',
+          '-r', resource.value(:revision),
+          *test_paths_parents)
         provider.expects(:svn).with('--non-interactive', 'update', '-r',
           resource.value(:revision),
-          '--parents',
           *resource[:includes])
         provider.create
       end
@@ -128,8 +134,10 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
           resource.value(:source),
           resource.value(:path))
         provider.expects(:svn).with('--non-interactive', 'update',
+          '--depth', 'empty',
+          *test_paths_parents)
+        provider.expects(:svn).with('--non-interactive', 'update',
           '--depth', resource.value(:depth),
-          '--parents',
           *resource[:includes])
         provider.create
       end
@@ -145,9 +153,12 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
           resource.value(:source),
           resource.value(:path))
         provider.expects(:svn).with('--non-interactive', 'update',
+          '--depth', 'empty',
+          '-r', resource.value(:revision),
+          *test_paths_parents)
+        provider.expects(:svn).with('--non-interactive', 'update',
           '-r', resource.value(:revision),
           '--depth', resource.value(:depth),
-          '--parents',
           *resource[:includes])
         provider.create
       end


### PR DESCRIPTION
- Handle sparse directory path updates recursively
- Always try to get around svn 1.6 sucking at sparse directories
  - Throw a warning when impossible
- Raise error when using `:includes` and svn < 1.6
- Updates to README