### PR TITLE
Fix muliple default provider warning on windows

### DIFF
--- a/lib/puppet/provider/vcsrepo/dummy.rb
+++ b/lib/puppet/provider/vcsrepo/dummy.rb
@@ -4,6 +4,7 @@ Puppet::Type.type(:vcsrepo).provide(:dummy, :parent => Puppet::Provider::Vcsrepo
   desc "Dummy default provider"
 
   defaultfor :feature => :posix
+  defaultfor :operatingsystem => :windows
 
   def working_copy_exists?
     providers = @resource.class.providers.map{|x| x.to_s}.sort.reject{|x| x == "dummy"}.join(", ") rescue "none"


### PR DESCRIPTION
Deployed vcsrepo on a windows 2012R2 server.  It was throwing a warning.  This cleans it up.