### PR TITLE
[MODULES-4139] Fix CI failures in CI on ubuntu 16.04 caused by regex matching on 16.04 when it is not meant to.

### DIFF
--- a/spec/acceptance/svn_paths_spec.rb
+++ b/spec/acceptance/svn_paths_spec.rb
@@ -4,7 +4,7 @@ tmpdir = default.tmpdir('vcsrepo')
 
 describe 'subversion :includes tests on SVN version >= 1.7', :unless => (
     (fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') =~ /(5|6)/) or
-    (fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') =~ /(6|7|10.04|12.04)/) or
+    (fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') =~ /^(6|7|10.04|12.04)/) or
     (fact('osfamily') == 'SLES')
 ) do
 
@@ -226,7 +226,6 @@ describe 'subversion :includes tests on SVN version == 1.6', :if => (
           revision => 1000000,
         }
       EOS
-
       # Run it twice and test for idempotency
       apply_manifest(pp, :catch_failures => true)
     end


### PR DESCRIPTION
The regex changed was ensuring the test within the if block only run on debian and ubuntu versions with SVN 1.6. However, the regex for debian 6 was matching on 16.04 also when it was not meant to.