### PR TITLE
(MODULES-1910) document non-standard SSH port

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -209,6 +209,17 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+To use SSH over a nonstandard port, use the full SSH scheme and include the port number:
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure   => latest,
+  provider => git,
+  source   => 'ssh://username@example.com:7999/repo.git',
+}
+~~~
+
+
 ### Bazaar
 
 #### Create a blank repository


### PR DESCRIPTION
Adds an example for using a non-standard SSH port by specifying the full
SSH scheme.