### PR TITLE
Fix to get svn provider working again

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
 
   def latest?
     at_path do
-      (self.revision >= self.latest) and (@resource.value(:source) == self.sourceurl)
+      (self.revision >= self.latest) and (@resource.value(:source) == self.source)
     end
   end
 


### PR DESCRIPTION
As by https://tickets.puppetlabs.com/browse/MODULES-4280
The svn provider is now broken.

Introduced by https://github.com/puppetlabs/puppetlabs-vcsrepo/commit/d26905fde50c4b8ce47dc0da7232028dc914a327#diff-574463866055cc3f49ee013638f6652aL80

PR not well tested.