### PR TITLE
(MODULES-5162) - Removing commented out test

### DIFF
--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -222,9 +222,6 @@ branches
       it "should raise an exception" do
         provider.expects(:path_exists?).returns(true)
         provider.expects(:path_empty?).returns(false)
-        ## this test can never succeed due to logic in
-        ##  create/check_force
-        # provider.expects(:working_copy_exists?).returns(false)
         expect { provider.create }.to raise_error(Puppet::Error)
       end
     end


### PR DESCRIPTION
It is not possible for the test to ever pass due to the logic in the
create/check_force. Removing this test rather than keeping it in the
code base commented out.