### PR TITLE
[MODULES-5615] Fix for working_copy_exists

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, :parent => Puppet::Provider::Vcsrepo) 
     return false if not File.directory?(@resource.value(:path))
     if @resource.value(:source)
       begin
-        svn('status', @resource.value(:path))
+        svn('info', @resource.value(:path))
         return true
       rescue Puppet::ExecutionFailure
         return false

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -175,10 +175,10 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
   end
 
   describe "checking existence" do
-    it "should run `svn status` on the path when there's a source" do
+    it "should run `svn info` on the path when there's a source" do
       resource[:source] = 'dummy'
       expects_directory?(true, resource.value(:path))
-      provider.expects(:svn).with('status', resource[:path])
+      provider.expects(:svn).with('info', resource[:path])
       provider.exists?
     end
     it "should run `svnlook uuid` on the path when there's no source" do


### PR DESCRIPTION
Change method 'working_copy_exists' to use 'svn info' instead of 'svn status'. 'svn status' does not return proper exit codes, while 'svn info' does.

Fixes https://tickets.puppetlabs.com/browse/MODULES-5615