### PR TITLE
(MODULES-5704) Fix cvs working copy detection

### DIFF
--- a/lib/puppet/provider/vcsrepo/cvs.rb
+++ b/lib/puppet/provider/vcsrepo/cvs.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:vcsrepo).provide(:cvs, :parent => Puppet::Provider::Vcsrepo) 
       directory = File.join(@resource.value(:path), 'CVS')
       return false if not File.directory?(directory)
       begin
-        at_path { runcvs('-nqd', @resource.value(:path), 'status', '-l') }
+        at_path { runcvs('-nq', 'status', '-l') }
         return true
       rescue Puppet::ExecutionFailure
         return false

--- a/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/cvs_spec.rb
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:cvs) do
         resource[:source] = ':ext:source@example.com:/foo/bar'
         File.expects(:directory?).with(File.join(resource.value(:path), 'CVS')).returns(true)
         expects_chdir
-        Puppet::Util::Execution.expects(:execute).with([:cvs, '-nqd', resource.value(:path), 'status', '-l'], :custom_environment => {}, :combine => true, :failonfail => true)
+        Puppet::Util::Execution.expects(:execute).with([:cvs, '-nq', 'status', '-l'], :custom_environment => {}, :combine => true, :failonfail => true)
         provider.exists?
       end
     end


### PR DESCRIPTION
The working copy detection for cvs if the source parameter is present fails
because the cvs -d option is only to specify the root repository and not the
working copy.