### PR TITLE
updates to changelog for 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,26 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.0] - 11/10/2017 Supported Release
+## Supported Release [2.1.0]
 
 ### Summary
 This is to provide a clean release from which to run Rebucop
 
 ### Added
-- Addition of Debian 9.
-### Changed
-- Fix to cvs working copy detection
-- Removal of Debian 6 and SLES 10.
+- Debian 9 as supported platform
+
+### Fixed
+- CVS working copy detection ([MODULES-5704](https://tickets.puppet.com/browse/MODULES-5704))
 - typo error for sshed-git-source
 - Update to existence test, Use 'svn info' instead of 'svn status'. 'svn status' does not return proper exit codes, while 'svn info' does.
-- Fix for working_copy_exists, Change method 'working_copy_exists' to use 'svn info' instead of 'svn status'. 'svn status' does not return proper exit codes, while 'svn info' does.
-- Remove unsupported Ubuntu
-- fixing tests associated with hg
+- working_copy_exists in svn provider. Change method 'working_copy_exists' to use 'svn info' instead of 'svn status'. 'svn status' does not return proper exit codes, while 'svn info' does. ([MODULES-5615](https://tickets.puppet.com/browse/MODULES-5615))
+- tests associated with hg
 - hg provider: remove escaped quotes - authentication fix
-- Removal of commented out test
+
+### Removed
+- Support for Ubuntu 10.04 and 12.04, existing compatibility is unaffected ([MODULES-5501](https://tickets.puppet.com/browse/MODULES-5501))
+- Support for Debian 6 and SLES 10, existing compatibility is unaffected
+- Commented out test ([MODULES-5162](https://tickets.puppet.com/browse/MODULES-5162))
 
 ## Supported Release [2.0.0]
 
@@ -231,6 +234,7 @@ our many contributors for all of these fixes!
 - CVS:
  - Documented the "module" attribute.
 
+[2.1.0]: https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/1.5.0...2.0.0
 [1.5.0]: https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/1.4.0...1.5.0
 [1.4.0]: https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/1.3.2...1.4.0


### PR DESCRIPTION
great job by @david22swan, just made some minor changes that may or may not be documented:
- updated entries that have an associated JIRA ticket to include a link to that ticket
- rearranged a few entries under new headings, 'Changed' should only be used for backwards-incomaptible changes
- removed date from release heading and added a link at the bottom of the page for 2.1.0
- added language around dropping support for platforms. we've had some churn about 'removing support' in the past and it's important to include a note about compatibility.
- changed language for some entries. we try to treat each heading as the
  beginning of a sentence, e.g. each entry under 'Fixed' should be a
continuation of a sentence that starts with the word 'Fixed...'