### PR TITLE
Do not ignore incorrect HTTP Basic auth property specifications.

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -19,11 +19,11 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       create_repository(@resource.value(:path))
     else
       if @resource.value(:basic_auth_username) && !@resource.value(:basic_auth_password)
-          fail("You must specify the HTTP basic authentication password for user '#{@resource.value(:basic_auth_username)}'")
+        raise("You must specify the HTTP basic authentication password for user '#{@resource.value(:basic_auth_username)}'")
       end
 
       if !@resource.value(:basic_auth_username) && @resource.value(:basic_auth_password)
-          fail("You must specify the HTTP basic authentication username")
+        raise('You must specify the HTTP basic authentication username')
       end
 
       checkout_repository(@resource.value(:source),

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -18,6 +18,14 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       end
       create_repository(@resource.value(:path))
     else
+      if @resource.value(:basic_auth_username) && !@resource.value(:basic_auth_password)
+          fail("You must specify the HTTP basic authentication password for user '#{@resource.value(:basic_auth_username)}'")
+      end
+
+      if !@resource.value(:basic_auth_username) && @resource.value(:basic_auth_password)
+          fail("You must specify the HTTP basic authentication username")
+      end
+
       checkout_repository(@resource.value(:source),
                           @resource.value(:path),
                           @resource.value(:revision),

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -249,6 +249,23 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     end
   end
 
+  describe 'checking the basic_auth properties' do
+    context 'when basic_auth_username is set and basic_auth_password is not set' do
+      it "should fail" do
+        resource[:source] = 'an-unimportant-value'
+        resource[:basic_auth_username] = 'dummy_user'
+        expect { provider.create }.to raise_error Puppet::Error, /you must specify the HTTP basic authentication password.+/i
+      end
+    end
+    context 'when basic_auth_username is not set and basic_auth_password is set' do
+      it "should fail" do
+        resource[:source] = 'an-unimportant-value'
+        resource[:basic_auth_password] = 'dummy_pass'
+        expect { provider.create }.to raise_error Puppet::Error, /you must specify the HTTP .+username.*/i
+      end
+    end
+  end
+
   describe 'setting the source property' do
     context 'with conflict' do
       it "uses 'svn switch'" do

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -251,17 +251,17 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
 
   describe 'checking the basic_auth properties' do
     context 'when basic_auth_username is set and basic_auth_password is not set' do
-      it "should fail" do
+      it 'fails' do
         resource[:source] = 'an-unimportant-value'
         resource[:basic_auth_username] = 'dummy_user'
-        expect { provider.create }.to raise_error Puppet::Error, /you must specify the HTTP basic authentication password.+/i
+        expect { provider.create }.to raise_error Puppet::Error, %r{you must specify the HTTP basic authentication password.+}i
       end
     end
     context 'when basic_auth_username is not set and basic_auth_password is set' do
-      it "should fail" do
+      it 'fails' do
         resource[:source] = 'an-unimportant-value'
         resource[:basic_auth_password] = 'dummy_pass'
-        expect { provider.create }.to raise_error Puppet::Error, /you must specify the HTTP .+username.*/i
+        expect { provider.create }.to raise_error Puppet::Error, %r{you must specify the HTTP .+username.*}i
       end
     end
   end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -254,14 +254,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it 'fails' do
         resource[:source] = 'an-unimportant-value'
         resource[:basic_auth_username] = 'dummy_user'
-        expect { provider.create }.to raise_error Puppet::Error, %r{you must specify the HTTP basic authentication password.+}i
+        expect { provider.create }.to raise_error RuntimeError, %r{you must specify the HTTP basic authentication password.+}i
       end
     end
     context 'when basic_auth_username is not set and basic_auth_password is set' do
       it 'fails' do
         resource[:source] = 'an-unimportant-value'
         resource[:basic_auth_password] = 'dummy_pass'
-        expect { provider.create }.to raise_error Puppet::Error, %r{you must specify the HTTP .+username.*}i
+        expect { provider.create }.to raise_error RuntimeError, %r{you must specify the HTTP .+username.*}i
       end
     end
   end


### PR DESCRIPTION
Throw an error with a descriptive error message when only one of the required
properties for enabling HTTP Basic auth is specified, as the user's true
intent isn't clear from such input. This contrasts with the previous behavior,
in which HTTP Basic auth was silently disabled.