### PR TITLE
(MODULES-5889) Add trust_server_cert support to Git provider

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -175,6 +175,17 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+To clone the repository and trust the server certificate (sslVerify=false), set `trust_server_cert` to 'true':
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure            => present,
+  provider          => git,
+  source            => 'git://example.com/repo.git',
+  trust_server_cert => true,
+}
+~~~
+
 #### Use multiple remotes with a repository
 
 In place of a single string, you can set `source` to a hash of one or more name => URL pairs:

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -545,6 +545,13 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # @!visibility private
   def git_with_identity(*args)
+    if @resource.value(:trust_server_cert) == :true
+      git_ver = git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
+      git_ver_err = "Can't set sslVerify to false, the -c parameter is not supported in Git #{git_ver}. Please install Git 1.7.2 or higher."
+      return raise(git_ver_err) unless Gem::Version.new(git_ver) >= Gem::Version.new('1.7.2')
+      args.unshift('-c', 'http.sslVerify=false')
+    end
+
     if @resource.value(:identity)
       Tempfile.open('git-helper', Puppet[:statedir]) do |f|
         f.puts '#!/bin/sh'


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/MODULES-5889

If the Git repo is hosted on a server with a self-signed certificate, you can't clone/pull it, as you can't pass along an sslverify=false parameter. The SVN variant has a "trust_server_cert" parameter, so I've reused that same parameter to feature the same thing for Git.

What the change does is add "-c http.sslVerify=false" to the Git command (not for 'local' calls). I've tried to stay in line with the same style of programming as the rest of the module.

Also added a check if you're using an up-to-date Git client, as the -c parameter wasn't supported before v1.7.2. The module will raise an error if you use "trust_server_cert => true", but your version of Git is too old.

I've tested this change on RHEL 6 with Git 1.7.1, CentOS 7 with Git 1.8.3.1 and Windows 2012 R2 with Git 2.13.3.