### PR TITLE
(MODULES-5889) Added trust_server_cert support to Git provider

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -175,6 +175,17 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+To clone the repository and trust the server certificate (sslVerify=false), set `trust_server_cert` to 'true':
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure            => present,
+  provider          => git,
+  source            => 'git://example.com/repo.git',
+  trust_server_cert => true,
+}
+~~~
+
 #### Use multiple remotes with a repository
 
 In place of a single string, you can set `source` to a hash of one or more name => URL pairs:

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -545,6 +545,13 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # @!visibility private
   def git_with_identity(*args)
+    if @resource.value(:trust_server_cert) == :true
+      git_ver = git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
+      git_ver_err = "Can't set sslVerify to false, the -c parameter is not supported in Git #{git_ver}. Please install Git 1.7.2 or higher."
+      return raise(git_ver_err) unless Gem::Version.new(git_ver) >= Gem::Version.new('1.7.2')
+      args.unshift('-c', 'http.sslVerify=false')
+    end
+
     if @resource.value(:identity)
       Tempfile.open('git-helper', Puppet[:statedir]) do |f|
         f.puts '#!/bin/sh'

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -543,10 +543,14 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     set_excludes if @resource.value(:excludes)
   end
 
+  def git_version
+    git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
+  end
+
   # @!visibility private
   def git_with_identity(*args)
     if @resource.value(:trust_server_cert) == :true
-      git_ver = git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
+      git_ver = git_version
       git_ver_err = "Can't set sslVerify to false, the -c parameter is not supported in Git #{git_ver}. Please install Git 1.7.2 or higher."
       return raise(git_ver_err) unless Gem::Version.new(git_ver) >= Gem::Version.new('1.7.2')
       args.unshift('-c', 'http.sslVerify=false')


### PR DESCRIPTION
closes #359 

- Added trust_server_cert support to Git provider
- Checking for Git version now, the -c parameter wasn't always available
- Moved the trust_server_cert part to git_with_identity, so it works for cloning, fetching, etc.
- Updated the README.
- Changed vcsrepo_git_ver regex to use %r{...}
- Using git('--version') now, removed Git version fact.