### PR TITLE
Avoid popup on macOS when developer tools aren't installed

### DIFF
--- a/lib/facter/vcsrepo_svn_ver.rb
+++ b/lib/facter/vcsrepo_svn_ver.rb
@@ -1,15 +1,15 @@
 Facter.add(:vcsrepo_svn_ver) do
   setcode do
     begin
-      unless Facter.value(:operatingsystem) == 'Darwin' and not File.directory?(Facter::Core::Execution.execute('xcode-select -p'))
+      if Facter.value(:operatingsystem) == 'Darwin' && !File.directory?(Facter::Core::Execution.execute('xcode-select -p'))
+        ''
+      else
         version = Facter::Core::Execution.execute('svn --version --quiet')
         if Gem::Version.new(version) > Gem::Version.new('0.0.1')
           version
         else
           ''
         end
-      else
-        ''
       end
     rescue StandardError
       ''

--- a/lib/facter/vcsrepo_svn_ver.rb
+++ b/lib/facter/vcsrepo_svn_ver.rb
@@ -1,9 +1,13 @@
 Facter.add(:vcsrepo_svn_ver) do
   setcode do
     begin
-      version = Facter::Core::Execution.execute('svn --version --quiet')
-      if Gem::Version.new(version) > Gem::Version.new('0.0.1')
-        version
+      unless Facter.value(:operatingsystem) == 'Darwin' and not File.directory?(Facter::Core::Execution.execute('xcode-select -p'))
+        version = Facter::Core::Execution.execute('svn --version --quiet')
+        if Gem::Version.new(version) > Gem::Version.new('0.0.1')
+          version
+        else
+          ''
+        end
       else
         ''
       end


### PR DESCRIPTION
On macOS ("Darwin"), check that the xcode-select path exists before attempting to run svn.  This avoids the popup dialog that is produced when the developer tools are not yet installed.