### PR TITLE
(FM-6697) Add error when a source is not specified with latest

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -151,7 +151,7 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-To keep the repository at the latest revision, set `ensure` to 'latest'.
+To keep the repository at the latest revision, set `ensure` to 'latest'. The 'latest' option requires `source` to be specified.
 
 **WARNING:** This overwrites any local changes to the repository.
 

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -12,14 +12,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   def create
     check_force
-    if @resource.value(:revision) && ensure_bare_or_mirror?
-      raise("Cannot set a revision (#{@resource.value(:revision)}) on a bare repository")
-    end
+    raise("Cannot set a revision (#{@resource.value(:revision)}) on a bare repository") if @resource.value(:revision) && ensure_bare_or_mirror?
+    raise('Cannot init repository with mirror option, try bare instead') if !@resource.value(:source) && @resource.value(:ensure) == :mirror
+    raise('Cannot init repository with latest option without specifying a source') if !@resource.value(:source) && @resource.value(:ensure) == :latest
     if !@resource.value(:source)
-      if @resource.value(:ensure) == :mirror
-        raise('Cannot init repository with mirror option, try bare instead')
-      end
-
       init_repository
     else
       clone_repository(default_url, @resource.value(:path))
@@ -452,7 +448,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   def on_branch?
     at_path do
       matches = git_with_identity('branch', '-a').match %r{\*\s+(.*)}
-      matches[1] unless matches[1] =~ %r{(\(detached from|\(HEAD detached at|\(no branch)}
+      matches[1] unless matches.nil? || matches[1] =~ %r{(\(detached from|\(HEAD detached at|\(no branch)}
     end
   end
 

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -211,6 +211,14 @@ BRANCHES
     end
   end
 
+  context 'when with an ensure of latest - without a source' do
+    it 'raises an exeption' do
+      resource[:ensure] = :latest
+      resource.delete(:source)
+      expect { provider.create }.to raise_error(RuntimeError, %r{Cannot init repository with latest option without specifying a source}i)
+    end
+  end
+
   context 'when when converting repo type' do
     context 'when with working copy to bare' do
       it 'converts the repo' do


### PR DESCRIPTION
This PR raises an error when the source is not specified when `ensure=>latest` using the git provider. Prior to this PR, the resource would create a bare repository and fail when checking the branches with a generic `nil:Nilclass` error.  