### PR TITLE
Revert "(FM-6697) Add error when a source is not specified with latest"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -151,7 +151,7 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
-To keep the repository at the latest revision, set `ensure` to 'latest'. The 'latest' option requires `source` to be specified.
+To keep the repository at the latest revision, set `ensure` to 'latest'.
 
 **WARNING:** This overwrites any local changes to the repository.
 

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -211,14 +211,6 @@ BRANCHES
     end
   end
 
-  context 'when with an ensure of latest - without a source' do
-    it 'raises an exeption' do
-      resource[:ensure] = :latest
-      resource.delete(:source)
-      expect { provider.create }.to raise_error(RuntimeError, %r{Cannot init repository with latest option without specifying a source}i)
-    end
-  end
-
   context 'when when converting repo type' do
     context 'when with working copy to bare' do
       it 'converts the repo' do


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-vcsrepo#371
This change caused test failures on the associated unit test