### PR TITLE
Mercurial process not honoring revision option

### DIFF
--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -80,7 +80,6 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
       begin
         hg_wrapper('merge')
       rescue Puppet::ExecutionFailure
-        next
         # If there's nothing to merge, just skip
       end
       hg_wrapper('update', '--clean', '-r', desired)

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -82,7 +82,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
       rescue Puppet::ExecutionFailure => e
         # Merge command exits with 255 code if there is nothing to do and we want to ignore that case
         # We look for 'has one head' as that line shows there's nothing there for it to try to merge
-        if ( e.to_s !~ (/has one head/) )
+        if e.to_s !~ %r{has one head}
           raise("Error merging #{@resource.value(:path)} Cannot update to #{desired}")
         end
       end

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -114,7 +114,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     it "uses 'hg update ---clean -r'" do
       expects_chdir
       provider.expects(:hg).with('pull')
-      provider.expects(:hg).with('merge')
+      provider.expects(:hg).with('merge', '--tool', ':merge3')
       provider.expects(:hg).with('update', '--clean', '-r', revision)
       provider.revision = revision
     end


### PR DESCRIPTION
When using mercurial the update process is only invoked when a merge can happen, which leads to unexpected behavior. The pull from remote is completed successfully but when a merge fails it will not update to the revision specified with the 'revision' option, thus not setting the repository to the desired state. The 'next' statement exits this loop, but what we want is to continue to the subsequent commands. 