### PR TITLE
MODULES-6898 Updating hg merge process to pass or catch errors

### DIFF
--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -78,10 +78,13 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
         next
       end
       begin
-        hg_wrapper('merge')
-      rescue Puppet::ExecutionFailure
-        next
-        # If there's nothing to merge, just skip
+        hg_wrapper('merge', '--tool', ':merge3')
+      rescue Puppet::ExecutionFailure => e
+        # Merge command exits with 255 code if there is nothing to do and we want to ignore that case
+        # We look for 'has one head' as that line shows there's nothing there for it to try to merge
+        if e.to_s !~ %r{has one head}
+          raise("Error merging #{@resource.value(:path)} Cannot update to #{desired}")
+        end
       end
       hg_wrapper('update', '--clean', '-r', desired)
     end

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -114,7 +114,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     it "uses 'hg update ---clean -r'" do
       expects_chdir
       provider.expects(:hg).with('pull')
-      provider.expects(:hg).with('merge', '--tool', ':merge3')
+      provider.expects(:hg).with('heads', '-q')
       provider.expects(:hg).with('update', '--clean', '-r', revision)
       provider.revision = revision
     end

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -114,7 +114,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     it "uses 'hg update ---clean -r'" do
       expects_chdir
       provider.expects(:hg).with('pull')
-      provider.expects(:hg).with('merge')
+      provider.expects(:hg).with('merge', '--tool', ':merge3')
       provider.expects(:hg).with('update', '--clean', '-r', revision)
       provider.revision = revision
     end

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -114,7 +114,6 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     it "uses 'hg update ---clean -r'" do
       expects_chdir
       provider.expects(:hg).with('pull')
-      provider.expects(:hg).with('heads', '-q')
       provider.expects(:hg).with('update', '--clean', '-r', revision)
       provider.revision = revision
     end


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/MODULES-6898

Merge process for mercurial does not properly account for errors and does not allow subsequent update command to run. This leads to not having the repo at the defined state and no messages generated to the user that it is not correct.