### PR TITLE
Improve Git performance when using SHA revisions

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -503,9 +503,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   # @return [String] Returns the tag/branch of the current repo if it's up to
   #                  date; otherwise returns the sha of the requested revision.
   def get_revision(rev = 'HEAD')
-    if @resource.value(:source)
-      update_references
-    else
+    unless @resource.value(:source)
       status = at_path { git_with_identity('status') }
       is_it_new = status =~ %r{Initial commit}
       if is_it_new
@@ -515,6 +513,13 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
       end
     end
     current = at_path { git_with_identity('rev-parse', rev).strip }
+    if @resource.value(:revision) == current
+      # if already pointed at desired revision, it must be a SHA, so just return it
+      return current
+    end
+    if @resource.value(:source)
+      update_references
+    end
     if @resource.value(:revision)
       canonical = if tag_revision?
                     # git-rev-parse will give you the hash of the tag object itself rather

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -209,7 +209,7 @@ BRANCHES
     end
   end
 
-  context 'when when converting repo type' do
+  context 'when converting repo type' do
     context 'when with working copy to bare' do
       it 'converts the repo' do
         resource[:ensure] = :bare
@@ -276,14 +276,14 @@ BRANCHES
     end
   end
 
-  context 'when when destroying' do
+  context 'when destroying' do
     it 'removes the directory' do
       expects_rm_rf
       provider.destroy
     end
   end
 
-  context 'when when checking the revision property' do
+  context 'when checking the revision property' do
     before(:each) do
       expects_chdir('/tmp/test')
       resource[:revision] = 'currentsha'
@@ -296,7 +296,7 @@ BRANCHES
       provider.stubs(:git).with('tag', '-l').returns('Hello')
     end
 
-    context 'when when its SHA is not different than the current SHA' do
+    context 'when its SHA is not different than the current SHA' do
       it 'returns the ref' do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
         provider.expects(:update_references)
@@ -304,7 +304,7 @@ BRANCHES
       end
     end
 
-    context 'when when its SHA is different than the current SHA' do
+    context 'when its SHA is different than the current SHA' do
       it 'returns the current SHA' do
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('othersha')
         provider.expects(:update_references)
@@ -312,7 +312,7 @@ BRANCHES
       end
     end
 
-    context 'when when its a ref to a remote head' do
+    context 'when its a ref to a remote head' do
       it 'returns the revision' do
         provider.stubs(:git).with('branch', '-a').returns("  remotes/origin/#{resource.value(:revision)}")
         provider.expects(:git).with('rev-parse', "origin/#{resource.value(:revision)}").returns('newsha')
@@ -321,7 +321,7 @@ BRANCHES
       end
     end
 
-    context 'when when its a ref to non existant remote head' do
+    context 'when its a ref to non existant remote head' do
       it 'fails' do
         provider.expects(:git).with('branch', '-a').returns(branch_a_list)
         provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('')

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -298,8 +298,8 @@ BRANCHES
       it 'returns the current SHA' do
         resource[:revision] = 'currentsha'
         provider.stubs(:git).with('branch', '-a').returns(branch_a_list)
-        provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('currentsha')
-        provider.expects(:update_references)
+        provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).never
+        provider.expects(:update_references).never
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -286,36 +286,59 @@ BRANCHES
   context 'when checking the revision property' do
     before(:each) do
       expects_chdir('/tmp/test')
-      resource[:revision] = 'currentsha'
       resource[:source] = 'http://example.com'
       provider.stubs(:git).with('config', 'remote.origin.url').returns('')
       provider.stubs(:git).with('fetch', 'origin') # FIXME
       provider.stubs(:git).with('fetch', '--tags', 'origin')
       provider.stubs(:git).with('rev-parse', 'HEAD').returns('currentsha')
-      provider.stubs(:git).with('branch', '-a').returns(branch_a_list(resource.value(:revision)))
       provider.stubs(:git).with('tag', '-l').returns('Hello')
     end
 
-    context 'when its SHA is not different than the current SHA' do
+    context 'when its a SHA and is not different than the current SHA' do
+      it 'returns the current SHA' do
+        resource[:revision] = 'currentsha'
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list)
+        provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('currentsha')
+        provider.expects(:update_references)
+        expect(provider.revision).to eq(resource.value(:revision))
+      end
+    end
+
+    context 'when its a SHA and is different than the current SHA' do
+      it 'returns the current SHA' do
+        resource[:revision] = 'othersha'
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list)
+        provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('othersha')
+        provider.expects(:update_references)
+        expect(provider.revision).to eq('currentsha')
+      end
+    end
+
+    context 'when its a local branch and is not different than the current SHA' do
       it 'returns the ref' do
+        resource[:revision] = 'localbranch'
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list('localbranch'))
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
         provider.expects(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end
 
-    context 'when its SHA is different than the current SHA' do
+    context 'when its a local branch and is different than the current SHA' do
       it 'returns the current SHA' do
+        resource[:revision] = 'localbranch'
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list('localbranch'))
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('othersha')
         provider.expects(:update_references)
-        expect(provider.revision).to eq(resource.value(:revision))
+        expect(provider.revision).to eq('currentsha')
       end
     end
 
     context 'when its a ref to a remote head' do
-      it 'returns the revision' do
+      it 'returns the ref' do
+        resource[:revision] = 'remotebranch'
         provider.stubs(:git).with('branch', '-a').returns("  remotes/origin/#{resource.value(:revision)}")
-        provider.expects(:git).with('rev-parse', "origin/#{resource.value(:revision)}").returns('newsha')
+        provider.expects(:git).with('rev-parse', "origin/#{resource.value(:revision)}").returns('currentsha')
         provider.expects(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
@@ -323,7 +346,8 @@ BRANCHES
 
     context 'when its a ref to non existant remote head' do
       it 'fails' do
-        provider.expects(:git).with('branch', '-a').returns(branch_a_list)
+        resource[:revision] = 'remotebranch'
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list)
         provider.expects(:git).with('rev-parse', '--revs-only', resource.value(:revision)).returns('')
         provider.expects(:update_references)
         expect { provider.revision }.to raise_error(RuntimeError, %r{not a local or remote ref$})
@@ -332,7 +356,10 @@ BRANCHES
 
     context "when there's no source" do
       it 'returns the revision' do
+        resource[:revision] = 'localbranch'
         resource.delete(:source)
+        provider.stubs(:git).with('branch', '-a').returns(branch_a_list('localbranch'))
+        provider.expects(:update_references).never
         provider.expects(:git).with('status')
         provider.expects(:git).with('rev-parse', resource.value(:revision)).returns('currentsha')
         expect(provider.revision).to eq(resource.value(:revision))


### PR DESCRIPTION
When using a SHA revision, a `git fetch` does not need to be done if the current HEAD is already pointing to the requested SHA. 