### PR TITLE
(MODULES-7675) - Add the option to specify a temporary directory for the git-helper script

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -431,6 +431,19 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+When specifying a identity key without a user, Puppet utilises an ephemeral helper script to clone the repository. To ensure Puppet writes the helper script to a location with executable permissions:
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure   => present,
+  provider => hg,
+  source   => 'ssh://hg@hg.example.com/myrepo',
+  identity => '/home/user/.ssh/id_dsa1',
+  tmp_dir  => '/var/tmp',
+}
+~~~
+
+
 To specify a username and password for HTTP Basic authentication:
 
 ~~~ puppet

--- a/README.markdown
+++ b/README.markdown
@@ -238,7 +238,7 @@ vcsrepo { '/path/to/repo':
   provider => git,
   source   => 'ssh://username@example.com/repo.git',
   identity => '/home/user/.ssh/id_dsa1',
-  tmp_dir  => '/var/tmp',
+  temp_dir => '/var/tmp',
 }
 ~~~
 

--- a/README.markdown
+++ b/README.markdown
@@ -230,6 +230,17 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+When specifying a identity key without a user, Puppet utilises an ephemeral helper script to clone the repository. To ensure Puppet writes the helper script to a location with executable permissions:
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure   => present,
+  provider => git,
+  source   => 'ssh://username@example.com/repo.git',
+  identity => '/home/user/.ssh/id_dsa1',
+  tmp_dir  => '/var/tmp',
+}
+~~~
 
 ### Bazaar
 
@@ -430,19 +441,6 @@ vcsrepo { '/path/to/repo':
   identity => '/home/user/.ssh/id_dsa1',
 }
 ~~~
-
-When specifying a identity key without a user, Puppet utilises an ephemeral helper script to clone the repository. To ensure Puppet writes the helper script to a location with executable permissions:
-
-~~~ puppet
-vcsrepo { '/path/to/repo':
-  ensure   => present,
-  provider => hg,
-  source   => 'ssh://hg@hg.example.com/myrepo',
-  identity => '/home/user/.ssh/id_dsa1',
-  tmp_dir  => '/var/tmp',
-}
-~~~
-
 
 To specify a username and password for HTTP Basic authentication:
 

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -562,7 +562,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
 
     if @resource.value(:identity)
-      temp_dir = @resource.value(:tmpdir) ? @resource.value(:tmpdir) : Puppet[:statedir]
+      temp_dir = @resource.value(:temp_dir) ? @resource.value(:temp_dir) : Puppet[:statedir]
       Tempfile.open('git-helper', temp_dir) do |f|
         f.puts '#!/bin/sh'
         f.puts 'SSH_AUTH_SOCKET='

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -562,7 +562,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
 
     if @resource.value(:identity)
-      Tempfile.open('git-helper', Puppet[:statedir]) do |f|
+      temp_dir = @resource.value(:tmpdir) ? @resource.value(:tmpdir) : Puppet[:statedir]
+      Tempfile.open('git-helper', temp_dir) do |f|
         f.puts '#!/bin/sh'
         f.puts 'SSH_AUTH_SOCKET='
         f.puts 'export SSH_AUTH_SOCKET'

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -289,6 +289,15 @@ Puppet::Type.newtype(:vcsrepo) do
     defaultto :false
   end
 
+  newparam :temp_dir, required_features: [:ssh_identity] do
+    desc 'The directory to write the ephemeral cloning script to.'
+    validate do |directory|
+        unless File.directory?(directory) and File.writable?(directory)
+            raise ArgumentError, "Directory #{directory} doesn't exist or is not writable."
+        end
+    end
+  end
+
   autorequire(:package) do
     ['git', 'git-core', 'mercurial', 'subversion']
   end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -292,9 +292,9 @@ Puppet::Type.newtype(:vcsrepo) do
   newparam :temp_dir, required_features: [:ssh_identity] do
     desc 'The directory to write the ephemeral cloning script to.'
     validate do |directory|
-        unless File.directory?(directory) and File.writable?(directory)
-            raise ArgumentError, "Directory #{directory} doesn't exist or is not writable."
-        end
+      unless File.directory?(directory) && File.writable?(directory)
+        raise ArgumentError, "Directory #{directory} doesn't exist or is not writable."
+      end
     end
   end
 


### PR DESCRIPTION
#248 changes the directory of the git-helper script to Puppet's `statedir` to work around the issue of a `noexec /tmp` mount. Unfortunately, this breaks vcsrepo on systems where the `statedir` exists on a `noexec` mount.

This PR addresses this issue by allowing users to specify a temporary directory to drop the git-helper script. If the temporary directory is not specify, it'll default back to the default `statedir`.