### PR TITLE
(maint) - Fix NOTICE for license

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,15 +1,20 @@
-Puppet Module - puppetlabs-vcsrepo
+vcsrepo puppet module
 
-Copyright 2018 Puppet, Inc.
+Copyright (C) 2010-2012 Puppet Labs Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Puppet Labs can be contacted at: info@puppetlabs.com
 
-    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This program and entire repository is free software; you can
+redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software
+Foundation; either version 2 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA


### PR DESCRIPTION
The change in https://github.com/puppetlabs/puppetlabs-vcsrepo/commit/a41f7fcae6bbe7a68fab12623c1ba0642cf5f226 was an oversight that was created using modulesync. This PR puts the NOTICE back to how it should be and aligns with the LICENSE file and the metdata.json entry.

This module remains as licensed under: GNU General Public License

