### PR TITLE
Use clearer error message for "This client is too old to work with the working copy"

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
         svn('info', @resource.value(:path))
         return true
       rescue Puppet::ExecutionFailure => detail
-        if detail.message =~ /This client is too old/
+        if detail.message =~ %r{This client is too old}
           raise Puppet::Error, detail.message
         end
         return false

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -44,7 +44,10 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       begin
         svn('info', @resource.value(:path))
         return true
-      rescue Puppet::ExecutionFailure
+      rescue Puppet::ExecutionFailure => detail
+        if detail.message =~ /This client is too old/
+          raise Puppet::Error, detail.message
+        end
         return false
       end
     else


### PR DESCRIPTION
Use a clearer error message for the case where the existing local repository was created by a more recent SVN version than the one currently in use.