### PR TITLE
(MODULES-8738) Allow Sensitive value for basic_auth_password

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -723,7 +723,7 @@ Parameters: `basic_auth_password`, `basic_auth_username`, `configuration`, `conf
 **Note:** Not all features are available with all providers.
 
 * `bare_repositories` - Differentiates between bare repositories and those with working copies. (Available with `git`.)
-* `basic_auth` - Supports HTTP Basic authentication. (Available with `svn`.)
+* `basic_auth` - Supports HTTP Basic authentication. (Available with `hg` and `svn`.)
 * `conflict` - Lets you decide how to resolve any conflicts between the source repository and your working copy. (Available with `svn`.)
 * `configuration` - Lets you specify the location of your configuration files. (Available with `svn`.)
 * `cvs_rsh` - Understands the `CVS_RSH` environment variable. (Available with `cvs`.)
@@ -746,7 +746,7 @@ All parameters are optional, except where specified otherwise.
 
 ##### `basic_auth_password`
 
-Specifies the password for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string. Default: none.
+Specifies the password for HTTP Basic authentication. (Requires the `basic_auth` feature.) Valid options: a string or Sensitive string. Default: none.
 
 ##### `basic_auth_username`
 

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -119,17 +119,23 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
     set_ownership if @resource.value(:owner) || @resource.value(:group)
   end
 
+  def sensitive?
+    (@resource.parameters.key?(:basic_auth_password) && @resource.parameters[:basic_auth_password].sensitive) ? true : false # Check if there is a sensitive parameter
+  end
+
   def hg_wrapper(*args)
     options = { remote: false }
     if !args.empty? && args[-1].is_a?(Hash)
       options.merge!(args.pop)
     end
 
+    sensitive = sensitive?
+
     if @resource.value(:basic_auth_username) && @resource.value(:basic_auth_password)
       args += [
         '--config', "auth.x.prefix=#{@resource.value(:source)}",
         '--config', "auth.x.username=#{@resource.value(:basic_auth_username)}",
-        '--config', "auth.x.password=#{@resource.value(:basic_auth_password)}",
+        '--config', "auth.x.password=#{sensitive ? @resource.value(:basic_auth_password).unwrap : @resource.value(:basic_auth_password)}",
         '--config', 'auth.x.schemes=http https'
       ]
     end
@@ -138,7 +144,6 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
       args += ['--ssh', "ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oChallengeResponseAuthentication=no -i #{@resource.value(:identity)}"]
     end
 
-    sensitive = (@resource.parameters.key?(:basic_auth_password) && @resource.parameters[:basic_auth_password].sensitive) ? true : false # Check if there is a sensitive parameter
     args.map! { |a| (a =~ %r{\s}) ? "'#{a}'" : a } # Adds quotes to arguments with whitespaces.
 
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -140,7 +140,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
 
     sensitive = (@resource.parameters.key?(:basic_auth_password) && @resource.parameters[:basic_auth_password].sensitive) ? true : false # Check if there is a sensitive parameter
     args.map! { |a| (a =~ %r{\s}) ? "'#{a}'" : a } # Adds quotes to arguments with whitespaces.
-    
+
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value
       Puppet::Util::Execution.execute("hg #{args.join(' ')}", uid: @resource.value(:user), failonfail: true, combine: true, sensitive: sensitive)
     else

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -140,6 +140,7 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
 
     sensitive = (@resource.parameters.key?(:basic_auth_password) && @resource.parameters[:basic_auth_password].sensitive) ? true : false # Check if there is a sensitive parameter
     args.map! { |a| (a =~ %r{\s}) ? "'#{a}'" : a } # Adds quotes to arguments with whitespaces.
+    
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value
       Puppet::Util::Execution.execute("hg #{args.join(' ')}", uid: @resource.value(:user), failonfail: true, combine: true, sensitive: sensitive)
     else

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -129,13 +129,11 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
       options.merge!(args.pop)
     end
 
-    sensitive = sensitive?
-
     if @resource.value(:basic_auth_username) && @resource.value(:basic_auth_password)
       args += [
         '--config', "auth.x.prefix=#{@resource.value(:source)}",
         '--config', "auth.x.username=#{@resource.value(:basic_auth_username)}",
-        '--config', "auth.x.password=#{sensitive ? @resource.value(:basic_auth_password).unwrap : @resource.value(:basic_auth_password)}",
+        '--config', "auth.x.password=#{sensitive? ? @resource.value(:basic_auth_password).unwrap : @resource.value(:basic_auth_password)}",
         '--config', 'auth.x.schemes=http https'
       ]
     end
@@ -147,9 +145,9 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
     args.map! { |a| (a =~ %r{\s}) ? "'#{a}'" : a } # Adds quotes to arguments with whitespaces.
 
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value
-      Puppet::Util::Execution.execute("hg #{args.join(' ')}", uid: @resource.value(:user), failonfail: true, combine: true, sensitive: sensitive)
+      Puppet::Util::Execution.execute("hg #{args.join(' ')}", uid: @resource.value(:user), failonfail: true, combine: true, sensitive: sensitive?)
     else
-      Puppet::Util::Execution.execute("hg #{args.join(' ')}", sensitive: sensitive)
+      Puppet::Util::Execution.execute("hg #{args.join(' ')}", sensitive: sensitive?)
     end
   end
 end

--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
     return false unless File.directory?(@resource.value(:path))
     if @resource.value(:source)
       begin
-        svn('info', @resource.value(:path))
+        svn_wrapper('info', @resource.value(:path))
         return true
       rescue Puppet::ExecutionFailure => detail
         if detail.message =~ %r{This client is too old}
@@ -96,14 +96,14 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
   def latest
     args = buildargs.push('info', '-r', 'HEAD')
     at_path do
-      svn(*args)[%r{^Revision:\s+(\d+)}m, 1]
+      svn_wrapper(*args)[%r{^Revision:\s+(\d+)}m, 1]
     end
   end
 
   def source
     args = buildargs.push('info')
     at_path do
-      svn(*args)[%r{^URL:\s+(\S+)}m, 1]
+      svn_wrapper(*args)[%r{^URL:\s+(\S+)}m, 1]
     end
   end
 
@@ -120,7 +120,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
     end
     args.push(desired)
     at_path do
-      svn(*args)
+      svn_wrapper(*args)
     end
     update_owner
   end
@@ -128,7 +128,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
   def revision
     args = buildargs.push('info')
     at_path do
-      svn(*args)[%r{^Revision:\s+(\d+)}m, 1]
+      svn_wrapper(*args)[%r{^Revision:\s+(\d+)}m, 1]
     end
   end
 
@@ -147,7 +147,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
     end
 
     at_path do
-      svn(*args)
+      svn_wrapper(*args)
     end
     update_owner
   end
@@ -167,12 +167,17 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
     update_includes(new_paths)
   end
 
+  def svn_wrapper(*args)
+    sensitive = (@resource.parameters.key?(:basic_auth_password) && @resource.parameters[:basic_auth_password].sensitive) ? true : false # Check if there is a sensitive parameter
+    Puppet::Util::Execution.execute("svn #{args.join(' ')}", sensitive: sensitive)
+  end
+
   private
 
   def get_includes(directory)
     at_path do
       args = buildargs.push('info', directory)
-      if svn(*args)[%r{^Depth:\s+(\w+)}m, 1] != 'empty'
+      if svn_wrapper(*args)[%r{^Depth:\s+(\w+)}m, 1] != 'empty'
         return directory[2..-1].gsub(File::SEPARATOR, '/')
       end
       Dir.entries(directory).map { |entry|
@@ -208,7 +213,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       else
         Puppet.debug "Vcsrepo[#{@resource.name}]: Can remove #{path} directly using svn"
         args = buildargs.push('update', '--set-depth', 'exclude', path)
-        svn(*args)
+        svn_wrapper(*args)
       end
 
       # Keep walking up the parent directories of this include until we find
@@ -217,7 +222,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
         entries = Dir.entries(path).sort
         break if entries != ['.', '..'] && entries != ['.', '..', '.svn']
         args = buildargs.push('update', '--set-depth', 'exclude', path)
-        svn(*args)
+        svn_wrapper(*args)
       end
     end
   end
@@ -234,7 +239,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       args.push('--depth', depth)
     end
     args.push(source, path)
-    svn(*args)
+    svn_wrapper(*args)
   end
 
   def create_repository(path)
@@ -260,7 +265,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
       parents = paths.map { |path| File.dirname(path) }
       parents = make_include_paths(parents)
       args.push(*parents)
-      svn(*args)
+      svn_wrapper(*args)
 
       args = buildargs.push('update')
       if @resource.value(:revision)
@@ -270,7 +275,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
         args.push('--depth', @resource.value(:depth))
       end
       args.push(*paths)
-      svn(*args)
+      svn_wrapper(*args)
     end
   end
 

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -292,4 +292,15 @@ Puppet::Type.newtype(:vcsrepo) do
   autorequire(:package) do
     ['git', 'git-core', 'mercurial', 'subversion']
   end
+
+  private
+
+  def set_sensitive_parameters(sensitive_parameters)
+    if sensitive_parameters.include?(:basic_auth_password)
+      sensitive_parameters.delete(:basic_auth_password)
+      parameter(:basic_auth_password).sensitive = true
+    end
+
+    super(sensitive_parameters)
+  end
 end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -295,7 +295,7 @@ Puppet::Type.newtype(:vcsrepo) do
 
   private
 
-  def set_sensitive_parameters(sensitive_parameters)
+  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Style/AccessorMethodName
     if sensitive_parameters.include?(:basic_auth_password)
       sensitive_parameters.delete(:basic_auth_password)
       parameter(:basic_auth_password).sensitive = true

--- a/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/hg_spec.rb
@@ -19,8 +19,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
       it "executes 'hg clone -u' with the revision" do
         resource[:source] = 'something'
         resource[:revision] = '1'
-        expect(provider).to receive(:hg).with('clone', '-u', resource.value(:revision),
-                                              resource.value(:source), resource.value(:path))
+        expect(Puppet::Util::Execution).to receive(:execute).with("hg clone -u #{resource.value(:revision)} #{resource.value(:source)} #{resource.value(:path)}", sensitive: false)
         provider.create
       end
     end
@@ -28,14 +27,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     context 'without revision' do
       it "justs execute 'hg clone' without a revision" do
         resource[:source] = 'something'
-        expect(provider).to receive(:hg).with('clone', resource.value(:source), resource.value(:path))
+        expect(Puppet::Util::Execution).to receive(:execute).with("hg clone #{resource.value(:source)} #{resource.value(:path)}", sensitive: false)
         provider.create
       end
     end
 
     context 'when a source is not given' do
       it "executes 'hg init'" do
-        expect(provider).to receive(:hg).with('init', resource.value(:path))
+        expect(Puppet::Util::Execution).to receive(:execute).with("hg init #{resource.value(:path)}", sensitive: false)
         provider.create
       end
     end
@@ -45,9 +44,12 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
         resource[:source] = 'something'
         resource[:basic_auth_username] = 'user'
         resource[:basic_auth_password] = 'pass'
-        expect(provider).to receive(:hg).with('clone', resource.value(:source), resource.value(:path), '--config',
-                                              'auth.x.prefix=' + resource.value(:source), '--config', 'auth.x.username=' + resource.value(:basic_auth_username),
-                                              '--config', 'auth.x.password=' + resource.value(:basic_auth_password), '--config', 'auth.x.schemes=http https')
+
+        command = "hg clone #{resource.value(:source)} #{resource.value(:path)} --config auth.x.prefix=#{resource.value(:source)} "\
+        "--config auth.x.username=#{resource.value(:basic_auth_username)} --config auth.x.password=#{resource.value(:basic_auth_password)} "\
+        "--config 'auth.x.schemes=http https'"\
+
+        expect(Puppet::Util::Execution).to receive(:execute).with(command, sensitive: false)
         provider.create
       end
     end
@@ -63,7 +65,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
   describe 'checking existence' do
     it 'checks for the directory' do
       expect_directory?(true, resource.value(:path))
-      expect(provider).to receive(:hg).with('status', resource.value(:path))
+      expect(Puppet::Util::Execution).to receive(:execute).with("hg status #{resource.value(:path)}", sensitive: false)
       provider.exists?
     end
   end
@@ -75,8 +77,8 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
 
     context 'when given a non-SHA as the resource revision' do
       before(:each) do
-        allow(provider).to receive(:hg).with('parents').and_return(fixture(:hg_parents))
-        allow(provider).to receive(:hg).with('tags').and_return(fixture(:hg_tags))
+        allow(Puppet::Util::Execution).to receive(:execute).with('hg parents', sensitive: false).and_return(fixture(:hg_parents))
+        allow(Puppet::Util::Execution).to receive(:execute).with('hg tags', sensitive: false).and_return(fixture(:hg_tags))
       end
 
       it 'when its sha is not different from the current SHA it and_return the ref' do
@@ -91,18 +93,18 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
     end
     context 'when given a SHA as the resource revision' do
       before(:each) do
-        allow(provider).to receive(:hg).with('parents').and_return(fixture(:hg_parents))
+        allow(Puppet::Util::Execution).to receive(:execute).with('hg parents', sensitive: false).and_return(fixture(:hg_parents))
       end
 
       it 'when it is the same as the current SHA it and_return it' do
         resource[:revision] = '34e6012c783a'
-        expect(provider).to receive(:hg).with('tags').and_return(fixture(:hg_tags))
+        expect(Puppet::Util::Execution).to receive(:execute).with('hg tags', sensitive: false).and_return(fixture(:hg_tags))
         expect(provider.revision).to eq(resource.value(:revision))
       end
 
       it 'when it is not the same as the current SHA it and_return the current SHA' do
         resource[:revision] = 'not-the-same'
-        expect(provider).to receive(:hg).with('tags').and_return(fixture(:hg_tags))
+        expect(Puppet::Util::Execution).to receive(:execute).with('hg tags', sensitive: false).and_return(fixture(:hg_tags))
         expect(provider.revision).to eq('34e6012c783a')
       end
     end
@@ -113,9 +115,9 @@ describe Puppet::Type.type(:vcsrepo).provider(:hg) do
 
     it "uses 'hg update ---clean -r'" do
       expect_chdir
-      expect(provider).to receive(:hg).with('pull')
-      expect(provider).to receive(:hg).with('merge')
-      expect(provider).to receive(:hg).with('update', '--clean', '-r', revision)
+      expect(provider).to receive(:hg_wrapper).with('pull', remote: true)
+      expect(provider).to receive(:hg_wrapper).with('merge')
+      expect(provider).to receive(:hg_wrapper).with('update', '--clean', '-r', revision)
       provider.revision = revision
     end
   end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'exists'
         resource[:revision] = '1'
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r', resource.value(:revision),
-                                               resource.value(:source), resource.value(:path))
+                                                       resource.value(:source), resource.value(:path))
         provider.create
       end
     end
@@ -31,8 +31,8 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "justs execute 'svn checkout' without a revision" do
         resource[:source] = 'exists'
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout',
-                                               resource.value(:source),
-                                               resource.value(:path))
+                                                       resource.value(:source),
+                                                       resource.value(:path))
         provider.create
       end
     end
@@ -58,7 +58,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'exists'
         resource[:depth] = 'infinity'
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'infinity',
-                                               resource.value(:source), resource.value(:path))
+                                                       resource.value(:source), resource.value(:path))
         provider.create
       end
     end
@@ -68,14 +68,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'exists'
         resource[:trust_server_cert] = false
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout',
-                                               resource.value(:source), resource.value(:path))
+                                                       resource.value(:source), resource.value(:path))
         provider.create
       end
       it "executes 'svn checkout' with a trust-server-cert" do
         resource[:source] = 'exists'
         resource[:trust_server_cert] = true
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', '--trust-server-cert', 'checkout',
-                                               resource.value(:source), resource.value(:path))
+                                                       resource.value(:source), resource.value(:path))
         provider.create
       end
     end
@@ -91,12 +91,12 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'empty',
-                                               resource.value(:source),
-                                               resource.value(:path))
+                                                       resource.value(:source),
+                                                       resource.value(:path))
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update', '--depth', 'empty',
-                                               *test_paths_parents)
+                                                       *test_paths_parents)
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               *resource[:includes])
+                                                       *resource[:includes])
         provider.create
       end
       it 'performs a sparse checkout at a specific revision' do
@@ -105,17 +105,17 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r',
-                                               resource.value(:revision),
-                                               '--depth', 'empty',
-                                               resource.value(:source),
-                                               resource.value(:path))
+                                                       resource.value(:revision),
+                                                       '--depth', 'empty',
+                                                       resource.value(:source),
+                                                       resource.value(:path))
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '--depth', 'empty',
-                                               '-r', resource.value(:revision),
-                                               *test_paths_parents)
+                                                       '--depth', 'empty',
+                                                       '-r', resource.value(:revision),
+                                                       *test_paths_parents)
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update', '-r',
-                                               resource.value(:revision),
-                                               *resource[:includes])
+                                                       resource.value(:revision),
+                                                       *resource[:includes])
         provider.create
       end
       it 'performs a sparse checkout with a specific depth' do
@@ -124,14 +124,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'empty',
-                                               resource.value(:source),
-                                               resource.value(:path))
+                                                       resource.value(:source),
+                                                       resource.value(:path))
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '--depth', 'empty',
-                                               *test_paths_parents)
+                                                       '--depth', 'empty',
+                                                       *test_paths_parents)
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '--depth', resource.value(:depth),
-                                               *resource[:includes])
+                                                       '--depth', resource.value(:depth),
+                                                       *resource[:includes])
         provider.create
       end
       it 'performs a sparse checkout at a specific depth and revision' do
@@ -141,18 +141,18 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r',
-                                               resource.value(:revision),
-                                               '--depth', 'empty',
-                                               resource.value(:source),
-                                               resource.value(:path))
+                                                       resource.value(:revision),
+                                                       '--depth', 'empty',
+                                                       resource.value(:source),
+                                                       resource.value(:path))
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '--depth', 'empty',
-                                               '-r', resource.value(:revision),
-                                               *test_paths_parents)
+                                                       '--depth', 'empty',
+                                                       '-r', resource.value(:revision),
+                                                       *test_paths_parents)
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '-r', resource.value(:revision),
-                                               '--depth', resource.value(:depth),
-                                               *resource[:includes])
+                                                       '-r', resource.value(:revision),
+                                                       '--depth', resource.value(:depth),
+                                                       *resource[:includes])
         provider.create
       end
     end
@@ -197,7 +197,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:conflict] = 'theirs-full'
         expect_chdir
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
-                                               '-r', revision, '--accept', resource.value(:conflict))
+                                                       '-r', revision, '--accept', resource.value(:conflict))
         provider.revision = revision
       end
     end
@@ -281,7 +281,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'http://example.com/svn/tags/1.0'
         expect_chdir
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch',
-                                               resource.value(:source))
+                                                       resource.value(:source))
         provider.source = resource.value(:source)
       end
     end

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "executes 'svn checkout' with a revision" do
         resource[:source] = 'exists'
         resource[:revision] = '1'
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '-r', resource.value(:revision),
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r', resource.value(:revision),
                                                resource.value(:source), resource.value(:path))
         provider.create
       end
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     context 'with source' do
       it "justs execute 'svn checkout' without a revision" do
         resource[:source] = 'exists'
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout',
                                                resource.value(:source),
                                                resource.value(:path))
         provider.create
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "executes 'svn checkout' with a depth" do
         resource[:source] = 'exists'
         resource[:depth] = 'infinity'
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '--depth', 'infinity',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'infinity',
                                                resource.value(:source), resource.value(:path))
         provider.create
       end
@@ -67,14 +67,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "executes 'svn checkout' without a trust-server-cert" do
         resource[:source] = 'exists'
         resource[:trust_server_cert] = false
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout',
                                                resource.value(:source), resource.value(:path))
         provider.create
       end
       it "executes 'svn checkout' with a trust-server-cert" do
         resource[:source] = 'exists'
         resource[:trust_server_cert] = true
-        expect(provider).to receive(:svn).with('--non-interactive', '--trust-server-cert', 'checkout',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', '--trust-server-cert', 'checkout',
                                                resource.value(:source), resource.value(:path))
         provider.create
       end
@@ -90,12 +90,12 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'exists'
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '--depth', 'empty',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'empty',
                                                resource.value(:source),
                                                resource.value(:path))
-        expect(provider).to receive(:svn).with('--non-interactive', 'update', '--depth', 'empty',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update', '--depth', 'empty',
                                                *test_paths_parents)
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                *resource[:includes])
         provider.create
       end
@@ -104,16 +104,16 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:revision] = 1
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '-r',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r',
                                                resource.value(:revision),
                                                '--depth', 'empty',
                                                resource.value(:source),
                                                resource.value(:path))
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '--depth', 'empty',
                                                '-r', resource.value(:revision),
                                                *test_paths_parents)
-        expect(provider).to receive(:svn).with('--non-interactive', 'update', '-r',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update', '-r',
                                                resource.value(:revision),
                                                *resource[:includes])
         provider.create
@@ -123,13 +123,13 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:depth] = 'files'
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '--depth', 'empty',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '--depth', 'empty',
                                                resource.value(:source),
                                                resource.value(:path))
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '--depth', 'empty',
                                                *test_paths_parents)
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '--depth', resource.value(:depth),
                                                *resource[:includes])
         provider.create
@@ -140,16 +140,16 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:depth] = 'files'
         resource[:includes] = test_paths
         expect(Dir).to receive(:chdir).with('/tmp/vcsrepo').once.and_yield
-        expect(provider).to receive(:svn).with('--non-interactive', 'checkout', '-r',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'checkout', '-r',
                                                resource.value(:revision),
                                                '--depth', 'empty',
                                                resource.value(:source),
                                                resource.value(:path))
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '--depth', 'empty',
                                                '-r', resource.value(:revision),
                                                *test_paths_parents)
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '-r', resource.value(:revision),
                                                '--depth', resource.value(:depth),
                                                *resource[:includes])
@@ -169,7 +169,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     it "runs `svn info` on the path when there's a source" do
       resource[:source] = 'dummy'
       expect_directory?(true, resource.value(:path))
-      expect(provider).to receive(:svn).with('info', resource[:path])
+      expect(provider).to receive(:svn_wrapper).with('info', resource[:path])
       provider.exists?
     end
     it "runs `svnlook uuid` on the path when there's no source" do
@@ -181,7 +181,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
 
   describe 'checking the revision property' do
     before(:each) do
-      allow(provider).to receive(:svn).with('--non-interactive', 'info').and_return(fixture(:svn_info))
+      allow(provider).to receive(:svn_wrapper).with('--non-interactive', 'info').and_return(fixture(:svn_info))
     end
     it "uses 'svn info'" do
       expect_chdir
@@ -196,7 +196,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "uses 'svn update'" do
         resource[:conflict] = 'theirs-full'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'update',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update',
                                                '-r', revision, '--accept', resource.value(:conflict))
         provider.revision = revision
       end
@@ -204,7 +204,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
     context 'without conflict' do
       it "uses 'svn update'" do
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'update', '-r', revision)
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'update', '-r', revision)
         provider.revision = revision
       end
     end
@@ -218,7 +218,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'an-unimportant-value'
         resource[:conflict] = 'theirs-full'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'switch', '-r', revision, 'an-unimportant-value', '--accept', resource.value(:conflict))
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch', '-r', revision, 'an-unimportant-value', '--accept', resource.value(:conflict))
         provider.revision = revision
       end
     end
@@ -226,14 +226,14 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "uses 'svn switch' - variation one" do
         resource[:source] = 'an-unimportant-value'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'switch', '-r', revision, 'an-unimportant-value')
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch', '-r', revision, 'an-unimportant-value')
         provider.revision = revision
       end
       it "uses 'svn switch' - variation two" do
         resource[:source] = 'an-unimportant-value'
         resource[:revision] = '30'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'switch', '-r', resource.value(:revision), 'an-unimportant-value')
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch', '-r', resource.value(:revision), 'an-unimportant-value')
         provider.source = resource.value(:source)
       end
     end
@@ -241,7 +241,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
 
   describe 'checking the source property' do
     before(:each) do
-      allow(provider).to receive(:svn).with('--non-interactive', 'info').and_return(fixture(:svn_info))
+      allow(provider).to receive(:svn_wrapper).with('--non-interactive', 'info').and_return(fixture(:svn_info))
     end
     it "uses 'svn info'" do
       expect_chdir
@@ -272,7 +272,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
         resource[:source] = 'http://example.com/svn/tags/1.0'
         resource[:conflict] = 'theirs-full'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'switch', '--accept', resource.value(:conflict), resource.value(:source))
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch', '--accept', resource.value(:conflict), resource.value(:source))
         provider.source = resource.value(:source)
       end
     end
@@ -280,7 +280,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
       it "uses 'svn switch'" do
         resource[:source] = 'http://example.com/svn/tags/1.0'
         expect_chdir
-        expect(provider).to receive(:svn).with('--non-interactive', 'switch',
+        expect(provider).to receive(:svn_wrapper).with('--non-interactive', 'switch',
                                                resource.value(:source))
         provider.source = resource.value(:source)
       end


### PR DESCRIPTION
The parameter basic_auth_password does not support Sensitive values. As such, passwords are logged in plain text. This change rectifies this by allowing the user to specify either a standard string or Sensitive value.