### PR TITLE
Don't set --branch equal to revision when depth > 0

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -336,9 +336,6 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     args = ['clone']
     if @resource.value(:depth) && @resource.value(:depth).to_i > 0
       args.push('--depth', @resource.value(:depth).to_s)
-      if @resource.value(:revision) && !@resource.value(:branch)
-        args.push('--branch', @resource.value(:revision).to_s)
-      end
     end
     if @resource.value(:branch)
       args.push('--branch', @resource.value(:branch).to_s)


### PR DESCRIPTION
Is there a historical reason why `--branch` is being set when `depth` > 0? When I set both `revision` and `depth` parameters, I get this error when trying to clone the repo:
```
Error: Execution of '/usr/bin/git clone --depth 1 --branch e668xxx https://un:pw@github.com/org/repo.git /var/www/api' returned 128: Cloning into '/var/www/api'...
warning: Could not find remote branch e668xxx to clone.
fatal: Remote branch e668xxx not found in upstream origin
Error: /Stage[main]/Role::Api/Vcsrepo[/var/www/api]/ensure: change from 'absent' to 'present' failed: Execution of '/usr/bin/git clone --depth 1 --branch e668xxx https://un:pw@github.com/org/repo.git /var/www/api' returned 128: Cloning into '/var/www/api'...
warning: Could not find remote branch e668xxx to clone.
fatal: Remote branch e668xxx not found in upstream origin
```

Here is my hiera define of the resource:
```
role::api::vcsrepo:
  '/var/www/api':
    ensure: present
    depth: 1
    provider: git
    revision: "%{::revision}"
    source: "https://un:pw@github.com/org/repo.git"
