### PR TITLE
feature(git): add keep local changes option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -157,6 +157,19 @@ vcsrepo { '/path/to/repo':
 }
 ~~~
 
+To keep local changes while changing revision, use the `keep_local_changes`:
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure             => present,
+  provider           => git,
+  source             => 'git://example.com/repo.git',
+  revision           => '0c466b8a5a45f6cd7de82c08df2fb4ce1e920a31',
+  keep_local_changes => true,
+  user               => 'someUser',
+}
+~~~
+
 To keep the repository at the latest revision, set `ensure` to 'latest'.
 
 **WARNING:** This overwrites any local changes to the repository.

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -56,6 +56,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :include_paths,
           'The provider supports checking out only specific paths'
 
+  feature :keep_local_changes,
+          'The provider supports keeping local changes on files tracked by the repository when changing revision'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -286,6 +289,12 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :trust_server_cert do
     desc 'Trust server certificate'
+    newvalues(true, false)
+    defaultto :false
+  end
+
+  newparam :keep_local_changes do
+    desc 'Keep local changes on files tracked by the repository when changing revision'
     newvalues(true, false)
     defaultto :false
   end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -402,6 +402,20 @@ BRANCHES
         provider.revision = resource.value(:revision)
       end
     end
+    context 'when ignoring local changes' do
+      it "uses 'git stash'" do
+        resource[:revision] = 'a-commit-or-tag'
+        resource[:keep_local_changes] = true
+        expect(provider).to receive(:git).with('stash', 'save')
+        expect(provider).to receive(:git).with('branch', '-a').once.and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:git).with('branch', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:git).with('branch', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:git).with('submodule', 'update', '--init', '--recursive')
+        expect(provider).to receive(:git).with('stash', 'pop')
+        provider.revision = resource.value(:revision)
+      end
+    end
   end
 
   context 'when checking the source property' do


### PR DESCRIPTION
Add an option to keep local changes when revision changes.
As we do a `git checkout --force` all local modifications are removed.
We just add an option that stash the modification before the checkout and
unstash the modification after the checkout.

This change is backward compatible, as by default, we keep the current
behaviour and do not keep local modification.