### PR TITLE
pdksync - Add support on Debian10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -460,6 +460,7 @@ describe 'clones a remote repo' do
         managehome => true,
       }
       MANIFEST
+      sleep 10
       apply_manifest(pp, catch_failures: true)
     end
   end


### PR DESCRIPTION
Add support on Debian10
pdk version: `1.12.0` 

added extra 10 seconds because the process was still running and test user couldn't be deleted