### PR TITLE
feat: do not chown excluded files

### DIFF
--- a/lib/puppet/provider/vcsrepo.rb
+++ b/lib/puppet/provider/vcsrepo.rb
@@ -16,7 +16,18 @@ class Puppet::Provider::Vcsrepo < Puppet::Provider
   def set_ownership
     owner = @resource.value(:owner) || nil
     group = @resource.value(:group) || nil
-    FileUtils.chown_R(owner, group, @resource.value(:path))
+    excludes = @resource.value(:excludes) || nil
+    if excludes.nil? || excludes.empty?
+      FileUtils.chown_R(owner, group, @resource.value(:path))
+    else
+      FileUtils.chown(owner, group, files)
+    end
+  end
+
+  def files
+    excludes = @resource.value(:excludes)
+    path = @resource.value(:path)
+    Dir["#{path}/**/*"].reject { |f| excludes.any? { |p| f.start_with?("#{path}/#{p}") } }
   end
 
   def path_exists?

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -563,4 +563,26 @@ BRANCHES
       end
     end
   end
+  context 'owner' do
+    it 'without excludes run FileUtils.chown_R' do
+      resource[:owner] = 'john'
+      expect_chdir
+      expect(FileUtils).to receive(:chown_R).with('john', nil, '/tmp/test')
+      expect(provider).to receive(:git).with('fetch', 'origin')
+      expect(provider).to receive(:git).with('fetch', '--tags', 'origin')
+      provider.update_references
+    end
+    it 'with excludes run filtered chown_R' do
+      resource[:owner] = 'john'
+      resource[:excludes] = ['bzr', 'cvs', 'hg', 'p4', 'svn']
+      expect_chdir
+      filtered_files = ['git/a', 'git/b']
+      expect(provider).to receive(:files).and_return(filtered_files)
+      expect(FileUtils).to receive(:chown).with('john', nil, filtered_files)
+      expect(provider).to receive(:set_excludes)
+      expect(provider).to receive(:git).with('fetch', 'origin')
+      expect(provider).to receive(:git).with('fetch', '--tags', 'origin')
+      provider.update_references
+    end
+  end
 end


### PR DESCRIPTION
When using puppetlabs-vcsrepo with the owner parameter (or
with the group parameter), the entire git repository is chowned
recursively on every update.

This chown can be very long if there are a lot of files in the
repository destination path. This commit excludes the files defined in
the `excludes` parameter in the chown.

refs https://tickets.puppetlabs.com/browse/MODULES-5922