### PR TITLE
Unset GIT_SSH_COMMAND before exec'ing git command

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -589,7 +589,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
         env_git_ssh_command_save = ENV['GIT_SSH_COMMAND']
 
         ENV['GIT_SSH']         = f.path
-        ENV['GIT_SSH_COMMAND'] = nil    # Unset GIT_SSH_COMMAND environment variable
+        ENV['GIT_SSH_COMMAND'] = nil # Unset GIT_SSH_COMMAND environment variable
 
         ret = git(*args)
 

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -584,12 +584,17 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
         f.close
 
         FileUtils.chmod(0o755, f.path)
-        env_save = ENV['GIT_SSH']
-        ENV['GIT_SSH'] = f.path
+
+        env_git_ssh_save         = ENV['GIT_SSH']
+        env_git_ssh_command_save = ENV['GIT_SSH_COMMAND']
+
+        ENV['GIT_SSH']         = f.path
+        ENV['GIT_SSH_COMMAND'] = nil    # Unset GIT_SSH_COMMAND environment variable
 
         ret = git(*args)
 
-        ENV['GIT_SSH'] = env_save
+        ENV['GIT_SSH']         = env_git_ssh_save
+        ENV['GIT_SSH_COMMAND'] = env_git_ssh_command_save
 
         return ret
       end


### PR DESCRIPTION
Per: "man git", GIT_SSH_COMMAND will take precedence over GIT_SSH. Thus,
if GIT_SSH_COMMAND is set and leaks into the environment, then this
module's use of the GIT_SSH environment variable will not work.

Unset GIT_SSH_COMMAND for the environment in which the git command
execs.