### PR TITLE
Run pdk update to obtain .travis.yml template update

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,8 +1,6 @@
 ---
 ".gitlab-ci.yml":
   delete: true
-".travis.yml":
-  unmanaged: true
 ".yardopts":
   optional:
   - "--output-dir docs/"
@@ -18,3 +16,92 @@ Gemfile:
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true
+'.travis.yml':
+  deploy_to_forge:
+    enabled: false
+  branches:
+    - release
+  user: puppet
+  secure: ''
+  includes:
+    - bundler_args:
+      dist: trusty
+      env: PLATFORMS=deb_puppet5
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_deb]'
+        - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+        - bundle exec rake 'litmus:install_agent[puppet5]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      stage: acceptance
+      sudo: required
+    - bundler_args:
+      dist: trusty
+      env: PLATFORM=centos:deb_puppet6
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_deb]'
+        - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+        - bundle exec rake 'litmus:install_agent[puppet6]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      sudo: required
+      stage: acceptance
+    - bundler_args:
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el6]'
+        - bundle exec rake 'litmus:install_agent[puppet5]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      sudo: required
+      stage: acceptance
+    - bundler_args:
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el7]'
+        - bundle exec rake 'litmus:install_agent[puppet5]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      sudo: required
+      stage: acceptance
+    - bundler_args:
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el6]'
+        - bundle exec rake 'litmus:install_agent[puppet6]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      stage: acceptance
+      sudo: required
+    - bundler_args:
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el7]'
+        - bundle exec rake 'litmus:install_agent[puppet6]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      stage: acceptance
+      sudo: required
+  simplecov: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:
@@ -13,99 +15,84 @@ script:
 bundler_args: --without system_tests
 rvm:
   - 2.5.3
-env:
-  global:
-    - PUPPET_GEM_VERSION="~> 6.0"
+stages:
+  - static
+  - spec
+  - acceptance
 matrix:
   fast_finish: true
   include:
     -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=debian_puppet5
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
-      - bundle exec rake 'litmus:install_agent[puppet5]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=debian_puppet6
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
-      - bundle exec rake 'litmus:install_agent[puppet6]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el6_puppet5
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el6]'
-      - bundle exec rake 'litmus:install_agent[puppet5]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el6_puppet6
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el6]'
-      - bundle exec rake 'litmus:install_agent[puppet6]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el7_puppet5
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el7]'
-      - bundle exec rake 'litmus:install_agent[puppet5]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el7_puppet6
-      rvm: 2.5.3
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el7]'
-      - bundle exec rake 'litmus:install_agent[puppet6]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
-    -
-      env: CHECK=parallel_spec
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      stage: static
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.5
+      stage: spec
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.3
+      stage: spec
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_deb]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=deb_puppet5
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_deb]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORM=centos:deb_puppet6
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el6]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el7]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el6]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el7]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
 branches:
   only:
     - master

--- a/metadata.json
+++ b/metadata.json
@@ -76,6 +76,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-gfaf9e8b",
-  "pdk-version": "1.14.1"
+  "template-ref": "heads/master-0-g73e79b9",
+  "pdk-version": "1.15.0"
 }


### PR DESCRIPTION
See full description here: puppetlabs/pdk-templates#300

.travis.yml was unmanaged by the PDK, which I have now removed. Could do with a 2nd opinion from someone who knows more about this particular module as to why this was the case and whether or not there would be adverse effects from merging this