### PR TITLE
Release prep version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v3.1.1](https://github.com/puppetlabs/puppetlabs-vcsrepo/tree/v3.1.1) (2020-06-25)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/v3.1.0...v3.1.1)
+
+### Fixed
+
+- prevent ANSI color escape sequences from messing up git output [\#458](https://github.com/puppetlabs/puppetlabs-vcsrepo/pull/458) ([kenyon](https://github.com/kenyon))
+- Unset GIT\_SSH\_COMMAND before exec'ing git command [\#435](https://github.com/puppetlabs/puppetlabs-vcsrepo/pull/435) ([mzagrabe](https://github.com/mzagrabe))
+
 ## [v3.1.0](https://github.com/puppetlabs/puppetlabs-vcsrepo/tree/v3.1.0) (2019-12-10)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/v3.0.0...v3.1.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-vcsrepo",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "puppetlabs",
   "summary": "Puppet module providing a type to manage repositories from various version control systems",
   "license": "GPL-2.0+",


### PR DESCRIPTION
Successful on 21 nodes: ["conceptual-deck.delivery.puppetlabs.net, sles-12-x86_64", "haughty-lookout.delivery.puppetlabs.net, ubuntu-1404-x86_64", "annual-banter.delivery.puppetlabs.net, sles-15-x86_64", "vigilant-maid.delivery.puppetlabs.net, redhat-6-x86_64", "fatal-tailor.delivery.puppetlabs.net, debian-8-x86_64", "foamy-least.delivery.puppetlabs.net, scientific-7-x86_64", "visual-luxury.delivery.puppetlabs.net, oracle-7-x86_64", "pretend-assault.delivery.puppetlabs.net, scientific-6-x86_64", "remote-legato.delivery.puppetlabs.net, centos-6-x86_64", "indirect-eva.delivery.puppetlabs.net, ubuntu-1604-x86_64", "concerted-while.delivery.puppetlabs.net, oracle-6-x86_64", "anomic-equine.delivery.puppetlabs.net, redhat-8-x86_64", "rougher-jest.delivery.puppetlabs.net, debian-9-x86_64", "pale-mat.delivery.puppetlabs.net, ubuntu-1804-x86_64", "fluffy-courtier.delivery.puppetlabs.net, centos-7-x86_64", "overt-consonant.delivery.puppetlabs.net, debian-10-x86_64", "exact-momentum.delivery.puppetlabs.net, redhat-7-x86_64", "mild-airflow.delivery.puppetlabs.net, centos-8-x86_64", "free-progeny.delivery.puppetlabs.net, oracle-5-x86_64", "unfixed-azalea.delivery.puppetlabs.net, centos-5-x86_64", "laden-floorshow.delivery.puppetlabs.net, redhat-5-x86_64"]