### PR TITLE
(IAC-1223) Correct clone https test

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -55,7 +55,7 @@ describe 'clones a remote repo' do
     end
 
     describe file("#{tmpdir}/httpstestrepo/.git/HEAD") do
-      it { is_expected.to contain 'ref: refs/heads/master' }
+      it { is_expected.to contain 'ref: refs/heads/main' }
     end
   end
 


### PR DESCRIPTION
With the default branch on github for the vcsrepo module being updated
from 'master' to 'main' when the module clones the default HEAD is now
'main' rather than 'master'.