### PR TITLE
Always run as given user, even if identity set

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -5,10 +5,6 @@ require File.join(File.dirname(__FILE__), '..', 'vcsrepo')
 Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   desc 'Supports Git repositories'
 
-  has_command(:git, 'git') do
-    environment('HOME' => ENV['HOME'])
-  end
-
   has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes,
                :user, :depth, :branch, :submodules
 
@@ -128,13 +124,13 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     at_path do
       if @resource.value(:source)
         begin
-          return git('config', '--get', "remote.#{@resource.value(:remote)}.url").chomp == default_url
+          return git_with_identity('config', '--get', "remote.#{@resource.value(:remote)}.url").chomp == default_url
         rescue Puppet::ExecutionFailure
           return false
         end
       else
         begin
-          git('status')
+          git_with_identity('status')
           return true
         rescue Puppet::ExecutionFailure
           return false
@@ -174,11 +170,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   def source
     at_path do
-      remotes = git('remote').split("\n")
+      remotes = git_with_identity('remote').split("\n")
 
-      return git('config', '--get', "remote.#{remotes[0]}.url").chomp if remotes.size == 1
+      return git_with_identity('config', '--get', "remote.#{remotes[0]}.url").chomp if remotes.size == 1
       Hash[remotes.map do |remote|
-        [remote, git('config', '--get', "remote.#{remote}.url").chomp]
+        [remote, git_with_identity('config', '--get', "remote.#{remote}.url").chomp]
       end]
     end
   end
@@ -247,7 +243,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     FileUtils.rm_rf(@resource.value(:path))
     FileUtils.mv(tempdir, @resource.value(:path))
     at_path do
-      git('config', '--local', '--bool', 'core.bare', 'true')
+      exec_git('config', '--local', '--bool', 'core.bare', 'true')
       return unless @resource.value(:ensure) == :mirror
       raise('Cannot have empty repository that is also a mirror.') unless @resource.value(:source)
       set_mirror
@@ -268,7 +264,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     FileUtils.mv(tempdir, File.join(@resource.value(:path), '.git'))
     if commits?
       at_path do
-        git('config', '--local', '--bool', 'core.bare', 'false')
+        exec_git('config', '--local', '--bool', 'core.bare', 'false')
         reset('HEAD')
         git_with_identity('checkout', '--force')
         update_owner_and_excludes
@@ -280,7 +276,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   def mirror?
     at_path do
       begin
-        git('config', '--get-regexp', 'remote\..*\.mirror')
+        git_with_identity('config', '--get-regexp', 'remote\..*\.mirror')
         return true
       rescue Puppet::ExecutionFailure
         return false
@@ -291,10 +287,10 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   def set_mirror
     at_path do
       if @resource.value(:source).is_a?(String)
-        git('config', "remote.#{@resource.value(:remote)}.mirror", 'true')
+        git_with_identity('config', "remote.#{@resource.value(:remote)}.mirror", 'true')
       else
         @resource.value(:source).each_key do |remote|
-          git('config', "remote.#{remote}.mirror", 'true')
+          git_with_identity('config', "remote.#{remote}.mirror", 'true')
         end
       end
     end
@@ -304,14 +300,14 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     at_path do
       if @resource.value(:source).is_a?(String)
         begin
-          git('config', '--unset', "remote.#{@resource.value(:remote)}.mirror")
+          exec_git('config', '--unset', "remote.#{@resource.value(:remote)}.mirror")
         rescue Puppet::ExecutionFailure
           next
         end
       else
         @resource.value(:source).each_key do |remote|
           begin
-            git('config', '--unset', "remote.#{remote}.mirror")
+            exec_git('config', '--unset', "remote.#{remote}.mirror")
           rescue Puppet::ExecutionFailure
             next
           end
@@ -326,7 +322,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   def bare_git_config_exists?
     return false unless File.exist?(File.join(@resource.value(:path), 'config'))
     begin
-      at_path { git('config', '--list', '--file', 'config') }
+      at_path { git_with_identity('config', '--list', '--file', 'config') }
       true
     rescue Puppet::ExecutionFailure
       false
@@ -564,7 +560,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   end
 
   def git_version
-    git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
+    exec_git('--version').match(%r{[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?})[0]
   end
 
   # @!visibility private
@@ -601,7 +597,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # Execute git with the given args, running it as the user specified.
   def exec_git(*args)
-    exec_args = { failonfail => true, combine => true }
+    exec_args = { failonfail: true, combine: true }
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value
       env = Etc.getpwnam(@resource.value(:user))
       exec_args[:custom_environment] = { 'HOME' => env['dir'] }

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -574,6 +574,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
     if @resource.value(:identity)
       ssh_opts = {
+        IgnoreUnknown: 'IdentityAgent',
         IdentitiesOnly: 'yes',
         IdentityAgent: 'none',
         PasswordAuthentication: 'no',

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -589,7 +589,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
       ENV['GIT_SSH_COMMAND'] = env_git_ssh_command_save
 
-      return ret
+      ret
     else
       exec_git(*args)
     end

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -475,6 +475,8 @@ describe 'clones a remote repo' do
       run_shell("mkdir -p #{homedir}/.ssh")
       run_shell("ssh-keygen -q -t rsa -f #{homedir}/.ssh/id_rsa -N ''")
 
+      run_shell("ssh-keyscan github.com >> #{homedir}/.ssh/known_hosts")
+ 
       # copy public key to authorized_keys
       run_shell("cat #{homedir}/.ssh/id_rsa.pub > #{homedir}/.ssh/authorized_keys")
       run_shell("echo -e \"Host localhost\\n\\tStrictHostKeyChecking no\\n\" > #{homedir}/.ssh/config")

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -439,8 +439,8 @@ describe 'clones a remote repo' do
       run_shell('ssh-keygen -q -t rsa -f /home/testuser-ssh/.ssh/id_rsa -N ""')
 
       # add localhost to known_hosts
-      run_shell('ssh-keygen -R localhost', expect_failures: true)
-      run_shell("ssh-keyscan localhost >> /home/testuser-ssh/.ssh/known_hosts")
+      run_shell('rm /home/testuser-ssh/.ssh/known_hosts', expect_failures: true)
+      run_shell('ssh-keyscan localhost >> /home/testuser-ssh/.ssh/known_hosts')
 
       # copy public key to authorized_keys
       run_shell('cat /home/testuser-ssh/.ssh/id_rsa.pub > /home/testuser-ssh/.ssh/authorized_keys')
@@ -479,7 +479,7 @@ describe 'clones a remote repo' do
       run_shell("mkdir -p #{homedir}/.ssh")
       run_shell("ssh-keygen -q -t rsa -f #{homedir}/.ssh/id_rsa -N ''")
 
-      run_shell('ssh-keygen -R localhost', expect_failures: true)
+      run_shell('rm ${homedir}/.ssh/known_hosts', expect_failures: true)
       run_shell("ssh-keyscan localhost >> #{homedir}/.ssh/known_hosts")
 
       # copy public key to authorized_keys

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper_acceptance'
 
 tmpdir = '/tmp/vcsrepo'
-homedir = '/tmp/' # set as /home/root/ for acceptance testing on containers
 
 describe 'clones a remote repo' do
   before(:all) do

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -506,6 +506,7 @@ describe 'clones a remote repo' do
         provider => git,
         source => "testuser-ssh@localhost:#{tmpdir}/testrepo.git",
         identity => '/home/testuser-ssh/.ssh/id_rsa',
+        user => 'testuser-ssh',
       }
     MANIFEST
     it 'applies the manifest' do

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -438,6 +438,10 @@ describe 'clones a remote repo' do
       run_shell('mkdir -p /home/testuser-ssh/.ssh')
       run_shell('ssh-keygen -q -t rsa -f /home/testuser-ssh/.ssh/id_rsa -N ""')
 
+      # add localhost to known_hosts
+      run_shell('ssh-keygen -R localhost', expect_failures: true)
+      run_shell("ssh-keyscan localhost >> /home/testuser-ssh/.ssh/known_hosts")
+
       # copy public key to authorized_keys
       run_shell('cat /home/testuser-ssh/.ssh/id_rsa.pub > /home/testuser-ssh/.ssh/authorized_keys')
       run_shell('echo -e "Host localhost\n\tStrictHostKeyChecking no\n" > /home/testuser-ssh/.ssh/config')
@@ -475,8 +479,9 @@ describe 'clones a remote repo' do
       run_shell("mkdir -p #{homedir}/.ssh")
       run_shell("ssh-keygen -q -t rsa -f #{homedir}/.ssh/id_rsa -N ''")
 
-      run_shell("ssh-keyscan github.com >> #{homedir}/.ssh/known_hosts")
- 
+      run_shell('ssh-keygen -R localhost', expect_failures: true)
+      run_shell("ssh-keyscan localhost >> #{homedir}/.ssh/known_hosts")
+
       # copy public key to authorized_keys
       run_shell("cat #{homedir}/.ssh/id_rsa.pub > #{homedir}/.ssh/authorized_keys")
       run_shell("echo -e \"Host localhost\\n\\tStrictHostKeyChecking no\\n\" > #{homedir}/.ssh/config")

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -477,22 +477,22 @@ describe 'clones a remote repo' do
     before(:all) do
       # create ssh keys
       run_shell("mkdir -p #{homedir}/.ssh")
-      run_shell("ssh-keygen -q -t rsa -f #{homedir}/.ssh/id_rsa -N ''")
+      run_shell("ssh-keygen -q -t rsa -f /home/testuser-ssh/.ssh/id_rsa -N ''")
 
-      run_shell('rm ${homedir}/.ssh/known_hosts', expect_failures: true)
-      run_shell("ssh-keyscan localhost >> #{homedir}/.ssh/known_hosts")
+      run_shell('rm /home/testuser-ssh/.ssh/known_hosts', expect_failures: true)
+      run_shell("ssh-keyscan localhost >> /home/testuser-ssh/.ssh/known_hosts")
 
       # copy public key to authorized_keys
-      run_shell("cat #{homedir}/.ssh/id_rsa.pub > #{homedir}/.ssh/authorized_keys")
-      run_shell("echo -e \"Host localhost\\n\\tStrictHostKeyChecking no\\n\" > #{homedir}/.ssh/config")
+      run_shell("cat /home/testuseruser-ssh/.ssh/id_rsa.pub > /home/testuser-ssh/.ssh/authorized_keys")
+      #run_shell("echo -e \"Host localhost\\n\\tStrictHostKeyChecking no\\n\" > /home/testuser-ssh/.ssh/config")
     end
 
     pp = <<-MANIFEST
       vcsrepo { "#{tmpdir}/testrepo_user_ssh_id":
         ensure => present,
         provider => git,
-        source => "root@localhost:#{tmpdir}/testrepo.git",
-        identity => '#{homedir}/.ssh/id_rsa',
+        source => "testuser-ssh@localhost:#{tmpdir}/testrepo.git",
+        identity => '/home/testuser-ssh/.ssh/id_rsa',
       }
     MANIFEST
     it 'applies the manifest' do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -35,11 +35,11 @@ BRANCHES
         resource[:revision] = 'only/remote'
         expect(Dir).to receive(:chdir).with('/').once.and_yield
         expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
-        expect(provider).to receive(:git).with('clone', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
         provider.create
       end
     end
@@ -49,11 +49,11 @@ BRANCHES
         resource[:remote] = 'not_origin'
         expect(Dir).to receive(:chdir).with('/').once.and_yield
         expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
-        expect(provider).to receive(:git).with('clone', '--origin', 'not_origin', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', '--origin', 'not_origin', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remote_url).with('not_origin', resource.value(:source)).and_return false
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
         provider.create
       end
     end
@@ -64,11 +64,11 @@ BRANCHES
         resource[:depth] = 1
         expect(Dir).to receive(:chdir).with('/').once.and_yield
         expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
-        expect(provider).to receive(:git).with('clone', '--depth', '1', '--branch', resource.value(:revision), resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', '--depth', '1', '--branch', resource.value(:revision), resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
         provider.create
       end
     end
@@ -78,17 +78,17 @@ BRANCHES
         resource[:revision] = 'a-commit-or-tag'
         expect(Dir).to receive(:chdir).with('/').once.and_yield
         expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
-        expect(provider).to receive(:git).with('clone', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
         provider.create
       end
 
       it "executes 'git clone' and submodule commands" do
         resource.delete(:revision)
-        expect(provider).to receive(:git).with('clone', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remotes)
         provider.create
@@ -102,7 +102,7 @@ BRANCHES
         expect_mkdir
         expect_chdir
         expect_directory?(false)
-        expect(provider).to receive(:git).with('init')
+        expect(provider).to receive(:exec_git).with('init')
         provider.create
       end
     end
@@ -125,7 +125,7 @@ BRANCHES
       it "justs execute 'git clone --bare'" do
         resource[:ensure] = :bare
         resource.delete(:revision)
-        expect(provider).to receive(:git).with('clone', '--bare', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', '--bare', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
         provider.create
       end
@@ -139,7 +139,7 @@ BRANCHES
         expect_chdir
         expect_mkdir
         expect_directory?(false)
-        expect(provider).to receive(:git).with('init', '--bare')
+        expect(provider).to receive(:exec_git).with('init', '--bare')
         provider.create
       end
     end
@@ -154,8 +154,7 @@ BRANCHES
       it "justs execute 'git clone --mirror'" do
         resource[:ensure] = :mirror
         resource.delete(:revision)
-        expect(Dir).to receive(:chdir).with('/').once.and_yield
-        expect(provider).to receive(:git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
         provider.create
       end
@@ -176,11 +175,11 @@ BRANCHES
         resource[:source] = { 'origin' => 'git://git@foo.com/bar.git', 'other' => 'git://git@foo.com/baz.git' }
         resource.delete(:revision)
         expect(Dir).to receive(:chdir).with('/').once.and_yield
-        expect(provider).to receive(:git).with('clone', '--mirror', resource.value(:source)['origin'], resource.value(:path))
+        expect(provider).to receive(:exec_git).with('clone', '--mirror', resource.value(:source)['origin'], resource.value(:path))
         expect(provider).to receive(:update_remotes)
         expect_chdir
-        expect(provider).to receive(:git).with('config', 'remote.origin.mirror', 'true')
-        expect(provider).to receive(:git).with('config', 'remote.other.mirror', 'true')
+        expect(provider).to receive(:exec_git).with('config', 'remote.origin.mirror', 'true')
+        expect(provider).to receive(:exec_git).with('config', 'remote.other.mirror', 'true')
         provider.create
       end
     end
@@ -194,11 +193,11 @@ BRANCHES
       expect(provider).to receive(:path_exists?).and_return(true)
       expect(provider).to receive(:path_empty?).and_return(false)
       provider.destroy
-      expect(provider).to receive(:git).with('clone', resource.value(:source), resource.value(:path))
+      expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
       expect(provider).to receive(:update_submodules)
       expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
-      expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-      expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
+      expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+      expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
       provider.create
     end
   end
@@ -221,7 +220,7 @@ BRANCHES
         expect(FileUtils).to receive(:rm_rf).and_return(true)
         expect(FileUtils).to receive(:mv).and_return(true)
         expect_chdir
-        expect(provider).to receive(:git).with('config', '--local', '--bool', 'core.bare', 'true')
+        expect(provider).to receive(:exec_git).with('config', '--local', '--bool', 'core.bare', 'true')
         provider.instance_eval { convert_working_copy_to_bare }
       end
     end
@@ -229,14 +228,14 @@ BRANCHES
     context 'when with working copy to mirror' do
       it 'converts the repo' do
         resource[:ensure] = :mirror
+        expect_chdir
         expect(provider).to receive(:working_copy_exists?).and_return(true)
         expect(provider).to receive(:bare_exists?).and_return(false)
         expect(FileUtils).to receive(:mv).and_return(true)
         expect(FileUtils).to receive(:rm_rf).and_return(true)
         expect(FileUtils).to receive(:mv).and_return(true)
-        expect_chdir
-        expect(provider).to receive(:git).with('config', '--local', '--bool', 'core.bare', 'true')
-        expect(provider).to receive(:git).with('config', 'remote.origin.mirror', 'true')
+        expect(provider).to receive(:exec_git).with('config', '--local', '--bool', 'core.bare', 'true')
+        expect(provider).to receive(:exec_git).with('config', 'remote.origin.mirror', 'true')
         provider.instance_eval { convert_working_copy_to_bare }
       end
     end
@@ -249,7 +248,7 @@ BRANCHES
         expect_chdir
         expect(provider).to receive(:commits?).and_return(true)
         # If you forget to stub these out you lose 3 hours of rspec work.
-        expect(provider).to receive(:git)
+        expect(provider).to receive(:exec_git)
           .with('config', '--local', '--bool', 'core.bare', 'false').and_return(true)
         expect(provider).to receive(:reset).with('HEAD').and_return(true)
         expect(provider).to receive(:git_with_identity).with('checkout', '--force').and_return(true)
@@ -266,12 +265,12 @@ BRANCHES
         expect(FileUtils).to receive(:mv).and_return(true)
         expect_chdir
         expect(provider).to receive(:commits?).and_return(true)
-        expect(provider).to receive(:git)
+        expect(provider).to receive(:exec_git)
           .with('config', '--local', '--bool', 'core.bare', 'false').and_return(true)
         expect(provider).to receive(:reset).with('HEAD').and_return(true)
         expect(provider).to receive(:git_with_identity).with('checkout', '--force').and_return(true)
         expect(provider).to receive(:update_owner_and_excludes).and_return(true)
-        expect(provider).to receive(:git).with('config', '--unset', 'remote.origin.mirror')
+        expect(provider).to receive(:exec_git).with('config', '--unset', 'remote.origin.mirror')
         expect(provider).to receive(:mirror?).and_return(true)
         provider.instance_eval { convert_bare_to_working_copy }
       end
@@ -289,18 +288,18 @@ BRANCHES
     before(:each) do
       expect_chdir('/tmp/test')
       resource[:source] = 'http://example.com'
-      allow(provider).to receive(:git).with('config', 'remote.origin.url').and_return('')
-      allow(provider).to receive(:git).with('fetch', 'origin') # FIXME
-      allow(provider).to receive(:git).with('fetch', '--tags', 'origin')
-      allow(provider).to receive(:git).with('rev-parse', 'HEAD').and_return('currentsha')
-      allow(provider).to receive(:git).with('tag', '-l').and_return('Hello')
+      allow(provider).to receive(:exec_git).with('config', 'remote.origin.url').and_return('')
+      allow(provider).to receive(:exec_git).with('fetch', 'origin') # FIXME
+      allow(provider).to receive(:exec_git).with('fetch', '--tags', 'origin')
+      allow(provider).to receive(:exec_git).with('rev-parse', 'HEAD').and_return('currentsha')
+      allow(provider).to receive(:exec_git).with('tag', '-l').and_return('Hello')
     end
 
     context 'when its a SHA and is not different than the current SHA' do
       it 'and_return the current SHA' do
         resource[:revision] = 'currentsha'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list)
-        expect(provider).to receive(:git).with('rev-parse', '--revs-only', resource.value(:revision)).never
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list)
+        expect(provider).to receive(:exec_git).with('rev-parse', '--revs-only', resource.value(:revision)).never
         expect(provider).to receive(:update_references).never
         expect(provider.revision).to eq(resource.value(:revision))
       end
@@ -309,8 +308,8 @@ BRANCHES
     context 'when its a SHA and is different than the current SHA' do
       it 'and_return the current SHA' do
         resource[:revision] = 'othersha'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list)
-        expect(provider).to receive(:git).with('rev-parse', '--revs-only', resource.value(:revision)).and_return('othersha')
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list)
+        expect(provider).to receive(:exec_git).with('rev-parse', '--revs-only', resource.value(:revision)).and_return('othersha')
         expect(provider).to receive(:update_references)
         expect(provider.revision).to eq('currentsha')
       end
@@ -319,8 +318,8 @@ BRANCHES
     context 'when its a local branch and is not different than the current SHA' do
       it 'and_return the ref' do
         resource[:revision] = 'localbranch'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
-        expect(provider).to receive(:git).with('rev-parse', resource.value(:revision)).and_return('currentsha')
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
+        expect(provider).to receive(:exec_git).with('rev-parse', resource.value(:revision)).and_return('currentsha')
         expect(provider).to receive(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
@@ -329,8 +328,8 @@ BRANCHES
     context 'when its a local branch and is different than the current SHA' do
       it 'and_return the current SHA' do
         resource[:revision] = 'localbranch'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
-        expect(provider).to receive(:git).with('rev-parse', resource.value(:revision)).and_return('othersha')
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
+        expect(provider).to receive(:exec_git).with('rev-parse', resource.value(:revision)).and_return('othersha')
         expect(provider).to receive(:update_references)
         expect(provider.revision).to eq('currentsha')
       end
@@ -339,8 +338,8 @@ BRANCHES
     context 'when its a ref to a remote head' do
       it 'and_return the ref' do
         resource[:revision] = 'remotebranch'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return("  remotes/origin/#{resource.value(:revision)}")
-        expect(provider).to receive(:git).with('rev-parse', "origin/#{resource.value(:revision)}").and_return('currentsha')
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return("  remotes/origin/#{resource.value(:revision)}")
+        expect(provider).to receive(:exec_git).with('rev-parse', "origin/#{resource.value(:revision)}").and_return('currentsha')
         expect(provider).to receive(:update_references)
         expect(provider.revision).to eq(resource.value(:revision))
       end
@@ -349,8 +348,8 @@ BRANCHES
     context 'when its a ref to non existant remote head' do
       it 'fails' do
         resource[:revision] = 'remotebranch'
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list)
-        expect(provider).to receive(:git).with('rev-parse', '--revs-only', resource.value(:revision)).and_return('')
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list)
+        expect(provider).to receive(:exec_git).with('rev-parse', '--revs-only', resource.value(:revision)).and_return('')
         expect(provider).to receive(:update_references)
         expect { provider.revision }.to raise_error(RuntimeError, %r{not a local or remote ref$})
       end
@@ -360,10 +359,10 @@ BRANCHES
       it 'and_return the revision' do
         resource[:revision] = 'localbranch'
         resource.delete(:source)
-        allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
+        allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list('localbranch'))
         expect(provider).to receive(:update_references).never
-        expect(provider).to receive(:git).with('status')
-        expect(provider).to receive(:git).with('rev-parse', resource.value(:revision)).and_return('currentsha')
+        expect(provider).to receive(:exec_git).with('status')
+        expect(provider).to receive(:exec_git).with('rev-parse', resource.value(:revision)).and_return('currentsha')
         expect(provider.revision).to eq(resource.value(:revision))
       end
     end
@@ -377,9 +376,9 @@ BRANCHES
       it "uses 'git fetch' and 'git reset'" do
         resource[:revision] = 'feature/foo'
         expect(provider).to receive(:update_submodules)
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').at_least(:once).and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:git).with('reset', '--hard', "origin/#{resource.value(:revision)}")
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').at_least(:once).and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('reset', '--hard', "origin/#{resource.value(:revision)}")
         provider.revision = resource.value(:revision)
       end
     end
@@ -387,20 +386,20 @@ BRANCHES
       it "uses 'git fetch' and 'git reset'" do
         resource[:revision] = 'only/remote'
         expect(provider).to receive(:update_submodules)
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').at_least(:once).and_return(resource.value(:revision))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:git).with('reset', '--hard', "origin/#{resource.value(:revision)}")
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').at_least(:once).and_return(resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('reset', '--hard', "origin/#{resource.value(:revision)}")
         provider.revision = resource.value(:revision)
       end
     end
     context "when it's a commit or tag" do
       it "uses 'git fetch' and 'git reset'" do
         resource[:revision] = 'a-commit-or-tag'
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').once.and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('submodule', 'update', '--init', '--recursive')
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').once.and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('submodule', 'update', '--init', '--recursive')
         provider.revision = resource.value(:revision)
       end
     end
@@ -408,13 +407,13 @@ BRANCHES
       it "uses 'git stash'" do
         resource[:revision] = 'a-commit-or-tag'
         resource[:keep_local_changes] = true
-        expect(provider).to receive(:git).with('stash', 'save')
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').once.and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
-        expect(provider).to receive(:git).with('submodule', 'update', '--init', '--recursive')
-        expect(provider).to receive(:git).with('stash', 'pop')
+        expect(provider).to receive(:exec_git).with('stash', 'save')
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').once.and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(fixture(:git_branch_a))
+        expect(provider).to receive(:exec_git).with('submodule', 'update', '--init', '--recursive')
+        expect(provider).to receive(:exec_git).with('stash', 'pop')
         provider.revision = resource.value(:revision)
       end
     end
@@ -422,30 +421,21 @@ BRANCHES
 
   context 'when checking the source property' do
     before(:each) do
-      expect_chdir('/tmp/test')
-      allow(provider).to receive(:git).with('config', 'remote.origin.url').and_return('')
-      allow(provider).to receive(:git).with('fetch', 'origin') # FIXME
-      allow(provider).to receive(:git).with('fetch', '--tags', 'origin')
-      allow(provider).to receive(:git).with('rev-parse', 'HEAD').and_return('currentsha')
-      allow(provider).to receive(:git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-      allow(provider).to receive(:git).with('tag', '-l').and_return('Hello')
-    end
-
-    context "when there's a single remote 'origin'" do
-      it 'and_return the URL for the remote' do
-        resource[:source] = 'http://example.com'
-        expect(provider).to receive(:git).with('remote').and_return("origin\n")
-        expect(provider).to receive(:git).with('config', '--get', 'remote.origin.url').and_return('http://example.com')
-        expect(provider.source).to eq(resource.value(:source))
-      end
+      allow(provider).to receive(:exec_git).with('config', 'remote.origin.url').and_return('')
+      allow(provider).to receive(:exec_git).with('fetch', 'origin') # FIXME
+      allow(provider).to receive(:exec_git).with('fetch', '--tags', 'origin')
+      allow(provider).to receive(:exec_git).with('rev-parse', 'HEAD').and_return('currentsha')
+      allow(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+      allow(provider).to receive(:exec_git).with('tag', '-l').and_return('Hello')
     end
 
     context "when there's more than one remote" do
       it 'and_return the remotes as a hash' do
         resource[:source] = { 'origin' => 'git://git@foo.com/bar.git', 'other' => 'git://git@foo.com/baz.git' }
-        expect(provider).to receive(:git).with('remote').and_return("origin\nother\n")
-        expect(provider).to receive(:git).with('config', '--get', 'remote.origin.url').and_return('git://git@foo.com/bar.git')
-        expect(provider).to receive(:git).with('config', '--get', 'remote.other.url').and_return('git://git@foo.com/baz.git')
+        expect_chdir
+        expect(provider).to receive(:exec_git).with('remote').and_return("origin\nother\n")
+        expect(provider).to receive(:exec_git).with('config', '--get', 'remote.origin.url').and_return('git://git@foo.com/bar.git')
+        expect(provider).to receive(:exec_git).with('config', '--get', 'remote.other.url').and_return('git://git@foo.com/baz.git')
         expect(provider.source).to eq(resource.value(:source))
       end
     end
@@ -472,11 +462,11 @@ BRANCHES
           'origin' => 'git://git@foo.com/foo.git',
           'old_remote' => 'git://git@foo.com/old.git',
         )
-        expect(provider).to receive(:git).once.with('config', '-l').and_return("remote.old_remote.url=git://git@foo.com/old.git\n", "remote.origin.url=git://git@foo.com/foo.git\n")
-        expect(provider).to receive(:git).with('remote', 'remove', 'old_remote')
-        expect(provider).to receive(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
-        expect(provider).to receive(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
-        expect(provider).to receive(:git).with('remote', 'update')
+        expect(provider).to receive(:exec_git).once.with('config', '-l').and_return("remote.old_remote.url=git://git@foo.com/old.git\n", "remote.origin.url=git://git@foo.com/foo.git\n")
+        expect(provider).to receive(:exec_git).with('remote', 'remove', 'old_remote')
+        expect(provider).to receive(:exec_git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
+        expect(provider).to receive(:exec_git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
+        expect(provider).to receive(:exec_git).with('remote', 'update')
         provider.source = resource.value(:source)
       end
     end
@@ -486,10 +476,10 @@ BRANCHES
         expect_chdir
         resource[:source] = { 'origin' => 'git://git@foo.com/bar.git', 'new_remote' => 'git://git@foo.com/baz.git' }
         expect(provider).to receive(:source).and_return('git://git@foo.com/foo.git')
-        expect(provider).to receive(:git).at_least(:once).with('config', '-l').and_return("remote.origin.url=git://git@foo.com/foo.git\n")
-        expect(provider).to receive(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
-        expect(provider).to receive(:git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
-        expect(provider).to receive(:git).with('remote', 'update')
+        expect(provider).to receive(:exec_git).at_least(:once).with('config', '-l').and_return("remote.origin.url=git://git@foo.com/foo.git\n")
+        expect(provider).to receive(:exec_git).with('remote', 'set-url', 'origin', 'git://git@foo.com/bar.git')
+        expect(provider).to receive(:exec_git).with('remote', 'add', 'new_remote', 'git://git@foo.com/baz.git')
+        expect(provider).to receive(:exec_git).with('remote', 'update')
         provider.source = resource.value(:source)
       end
     end
@@ -502,10 +492,10 @@ BRANCHES
           'origin' => 'git://git@foo.com/foo.git',
           'old_remote' => 'git://git@foo.com/old.git',
         )
-        expect(provider).to receive(:git).with('remote', 'remove', 'old_remote')
-        expect(provider).to receive(:git).with('config', '-l').at_most(:twice).and_return("remote.origin.url=git://git@foo.com/foo.git\n", "remote.other.url=git://git@foo.com/bar.git\n")
-        expect(provider).to receive(:git).with('remote', 'set-url', 'origin', 'git://git@foo.com/baz.git')
-        expect(provider).to receive(:git).with('remote', 'update')
+        expect(provider).to receive(:exec_git).with('remote', 'remove', 'old_remote')
+        expect(provider).to receive(:exec_git).with('config', '-l').at_most(:twice).and_return("remote.origin.url=git://git@foo.com/foo.git\n", "remote.other.url=git://git@foo.com/bar.git\n")
+        expect(provider).to receive(:exec_git).with('remote', 'set-url', 'origin', 'git://git@foo.com/baz.git')
+        expect(provider).to receive(:exec_git).with('remote', 'update')
         provider.source = resource.value(:source)
       end
     end
@@ -517,8 +507,8 @@ BRANCHES
     it "uses 'git fetch --tags'" do
       resource.delete(:source)
       expect_chdir
-      expect(provider).to receive(:git).with('fetch', 'origin')
-      expect(provider).to receive(:git).with('fetch', '--tags', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', '--tags', 'origin')
       provider.update_references
     end
   end
@@ -547,20 +537,20 @@ BRANCHES
       end
 
       it 'raises error with git 1.7.0' do
-        allow(provider).to receive(:git).with('--version').and_return '1.7.0'
+        allow(provider).to receive(:exec_git).with('--version').and_return '1.7.0'
         expect { provider.create }.to raise_error RuntimeError, %r{Can't set sslVerify to false}
       end
       it 'compiles with git 2.13.0' do
         resource[:revision] = 'only/remote'
         expect(Dir).to receive(:chdir).with('/').once.and_yield
         expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
-        expect(provider).to receive(:git).with('-c', 'http.sslVerify=false', 'clone', resource.value(:source), resource.value(:path))
+        expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
-        expect(provider).to receive(:git).with('-c', 'http.sslVerify=false', 'branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
-        expect(provider).to receive(:git).with('-c', 'http.sslVerify=false', 'checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
+        expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'checkout', '--force', resource.value(:revision))
 
-        allow(provider).to receive(:git).with('--version').and_return '2.13.0'
+        allow(provider).to receive(:exec_git).with('--version').and_return '2.13.0'
         expect { provider.create }.not_to raise_error
       end
     end
@@ -570,8 +560,8 @@ BRANCHES
       resource[:owner] = 'john'
       expect_chdir
       expect(FileUtils).to receive(:chown_R).with('john', nil, '/tmp/test')
-      expect(provider).to receive(:git).with('fetch', 'origin')
-      expect(provider).to receive(:git).with('fetch', '--tags', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', '--tags', 'origin')
       provider.update_references
     end
     it 'with excludes run filtered chown_R' do
@@ -582,8 +572,8 @@ BRANCHES
       expect(provider).to receive(:files).and_return(filtered_files)
       expect(FileUtils).to receive(:chown).with('john', nil, filtered_files)
       expect(provider).to receive(:set_excludes)
-      expect(provider).to receive(:git).with('fetch', 'origin')
-      expect(provider).to receive(:git).with('fetch', '--tags', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', 'origin')
+      expect(provider).to receive(:exec_git).with('fetch', '--tags', 'origin')
       provider.update_references
     end
   end


### PR DESCRIPTION
Previously, if the resource specified `user`, then git would be executed as that user... except if you also provided `identity` to control which SSH key to use, in which case the code did the setup required for the git helper script, then called git directly (bypassing the bit that ran it as the desired user).

This changes it by wrapping up the execution of git in a new method which contains the logic to run as the specified user if they asked for that, and uses that wrapper from both places in git_with_identity.