### PR TITLE
(MODULES-9997) - Removing extra unwrap on Sensitive value

### DIFF
--- a/lib/puppet/provider/vcsrepo/svn.rb
+++ b/lib/puppet/provider/vcsrepo/svn.rb
@@ -86,7 +86,7 @@ Puppet::Type.type(:vcsrepo).provide(:svn, parent: Puppet::Provider::Vcsrepo) do
     args = ['--non-interactive']
     if @resource.value(:basic_auth_username) && @resource.value(:basic_auth_password)
       args.push('--username', @resource.value(:basic_auth_username))
-      args.push('--password', sensitive? ? @resource.value(:basic_auth_password).unwrap : @resource.value(:basic_auth_password))
+      args.push('--password', @resource.value(:basic_auth_password))
       args.push('--no-auth-cache')
     end
 

--- a/spec/acceptance/svn_spec.rb
+++ b/spec/acceptance/svn_spec.rb
@@ -111,6 +111,23 @@ describe 'subversion tests' do
     end
   end
 
+  context 'with Sensitive password' do
+    pp = <<-MANIFEST
+      vcsrepo { 'SVN':
+      ensure => latest,
+      path => '/tmp/svn',
+      provider => svn,
+      source => 'http://svn.apache.org/repos/asf/subversion/svn-logos',
+      basic_auth_username => 'svn_user',
+      basic_auth_password => Sensitive('sensitivePassword'),
+    }
+    MANIFEST
+    it 'can use Sensitive' do
+      # Run it twice and test for idempotency
+      idempotent_apply(pp)
+    end
+  end
+
   context 'with switching sources' do
     pp = <<-MANIFEST
       vcsrepo { "#{tmpdir}/svnrepo":

--- a/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/svn_spec.rb
@@ -280,7 +280,7 @@ describe Puppet::Type.type(:vcsrepo).provider(:svn) do
 
       it 'works' do
         expect(provider).to receive(:svn_wrapper).with('--non-interactive', '--username', resource.value(:basic_auth_username),
-                                                       '--password', resource.value(:basic_auth_password).unwrap, '--no-auth-cache',
+                                                       '--password', resource.value(:basic_auth_password), '--no-auth-cache',
                                                        'checkout', resource.value(:source), resource.value(:path))
         provider.create
       end


### PR DESCRIPTION
Removing unwrap. When it is called, unwrap is a puppet method, therefore not available in Ruby and throws an error. Also the value is unwrapped earlier, therefore it is pretty much trying to unwrap the value twice. 

Adding an acceptance test to confirm the Sensitive value works.

The following PR is adding the same test as added here, and all acceptance tests are failing which proves this fix is needed.
https://github.com/puppetlabs/puppetlabs-vcsrepo/pull/492