### PR TITLE
pdksync - (IAC-1753) - Add Support for AlmaLinux 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,12 @@
       "operatingsystemrelease": [
         "8"
       ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
(IAC-1753) - Add Support for AlmaLinux 8
pdk version: `2.1.0` 
