### PR TITLE
MODULES-11050 - Force fetch tags

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -226,9 +226,14 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   end
 
   def update_references
+    fetch_tags_args = ['fetch', '--tags']
+    git_ver = git_version
+    if Gem::Version.new(git_ver) >= Gem::Version.new('2.20.0')
+      fetch_tags_args.push('--force')
+    end
     at_path do
       git_with_identity('fetch', @resource.value(:remote))
-      git_with_identity('fetch', '--tags', @resource.value(:remote))
+      git_with_identity(*fetch_tags_args, @resource.value(:remote))
       update_owner_and_excludes
     end
   end


### PR DESCRIPTION
On Git revisions 2.20.0 in order to force sync remote tags with local
ones, the parameter --force has to be passed or an error will be
raised.

On previous versions the --force behaviour was the default