### PR TITLE
support umask for git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ vcsrepo { '/path/to/repo':
 You can find more information about the proxy configuration [here](https://gist.github.com/evantoli/f8c23a37eb3558ab8765).
 It's also possible to configure it on a per-repository level.
 
+To use a specific umask, set `umask` to the desired value (expressed as a string of octal numbers); note that changes to umask do not retroactively affect repo files created earlier under a different umask. This is currently only implemented for the `git` provider. If unspecified, this will use the umask of the puppet process itself.
+
+Example to set shared group access:
+
+~~~ puppet
+vcsrepo { '/path/to/repo':
+  ensure   => present,
+  provider => git,
+  source   => 'git://example.com/repo.git',
+  revision => '0c466b8a5a45f6cd7de82c08df2fb4ce1e920a31',
+  umask    => '0002'
+}
+~~~
+
 #### Use multiple remotes with a repository
 
 In place of a single string, you can set `source` to a hash of one or more name => URL pairs:

--- a/lib/puppet/provider/vcsrepo.rb
+++ b/lib/puppet/provider/vcsrepo.rb
@@ -57,4 +57,16 @@ class Puppet::Provider::Vcsrepo < Puppet::Provider
   def tempdir
     @tempdir ||= File.join(Dir.tmpdir, 'vcsrepo-' + Digest::MD5.hexdigest(@resource.value(:path)))
   end
+
+  # If the resource has a umask, then run the block with that umask; otherwise,
+  # run the block directly.
+  def withumask
+    if @resource.value(:umask)
+      Puppet::Util.withumask(@resource.value(:umask)) do
+        yield
+      end
+    else
+      yield
+    end
+  end
 end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   desc 'Supports Git repositories'
 
   has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes,
-               :user, :depth, :branch, :submodules, :safe_directory, :hooks_allowed
+               :user, :depth, :branch, :submodules, :safe_directory, :hooks_allowed,
+               :umask
 
   def create
     check_force
@@ -699,6 +700,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
       exec_args[:custom_environment] = { 'HOME' => Etc.getpwnam(@resource.value(:user)).dir }
       exec_args[:uid] = @resource.value(:user)
     end
-    Puppet::Util::Execution.execute([:git, args], **exec_args)
+    withumask do
+      Puppet::Util::Execution.execute([:git, args], **exec_args)
+    end
   end
 end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -67,6 +67,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :hooks_allowed,
           'The provider supports managing hooks for the repository operations.'
 
+  feature :umask,
+          'The provider supports setting umask for repo operations'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -318,6 +321,17 @@ Puppet::Type.newtype(:vcsrepo) do
   newproperty :skip_hooks, required_features: [:hooks_allowed] do
     desc 'Explicitly skip any global hooks for this repository.'
     newvalues(:true, :false)
+  end
+
+  newparam :umask, required_features: [:umask] do
+    desc 'Sets the umask to be used for all repo operations'
+
+    # originally from puppet's built-in lib/puppet/type/exec.rb
+    # ...then modified to satisfy rubocop.
+    munge do |value|
+      raise Puppet::Error, _('The umask specification is invalid: %{value}') % { value: value.inspect } unless value.match?(%r{^0?[0-7]{1,4}$})
+      value.to_i(8)
+    end
   end
 
   autorequire(:package) do

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -598,4 +598,25 @@ describe 'clones a remote repo' do
       end
     end
   end
+
+  context 'with umask' do
+    pp = <<-MANIFEST
+      vcsrepo { "#{tmpdir}/testrepo_branch":
+        ensure => present,
+        provider => git,
+        source => "file://#{tmpdir}/testrepo.git",
+        umask => '0002',
+      }
+    MANIFEST
+    it 'clones a repo' do
+      # Run it twice and test for idempotency
+      idempotent_apply(pp)
+    end
+
+    describe file("#{tmpdir}/testrepo_branch/.git/HEAD") do
+      # Note: '0664' is not supported by 'be_mode'; this must be three digits
+      # unless the first octet is non-zero.
+      it { is_expected.to be_mode '664' }
+    end
+  end
 end


### PR DESCRIPTION
When cloning a repo, it can be useful to have shared access such that
other members of the cloning user's group are able to manage the repo as
well. This requires two components:

1. The setgid bit to be set on directories; this can be accomplished by
   puppet code which creates the repo directory before calling vcsrepo.
2. A umask that allows group writeability to be used during the clone.

This patch implements the second component. Note that for git,
specifically, there is a core.sharedRepository option, but this only
seems to be respected on 'git init', not 'git clone'. By default, git
will respect the umask anyhow.

I do not have ready access to the other version control systems, so I
only implemented this for git, but using a umask is likely portable to
other version control systems as well.