### PR TITLE
(GH-535) Fix for safe directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The vcsrepo module provides a single type with providers to support the followin
 * [Subversion](#subversion)
 
 **Note:** `git` is the only vcs provider officially [supported by Puppet Inc.](https://forge.puppet.com/supported)
-**Note:** Release v4.0.1 has been removed from the Puppet Forge and was officially re-released as version v5.0.0 as it contained a breaking change. Details available [here](https://puppetlabs.github.io/iac/team/status/developer/2021/06/04/status-update.html)
+**Note:** Release v4.0.1 has been removed from the Puppet Forge and was officially re-released as version v5.0.0 as it contained a breaking change.
+Details available [here](https://puppetlabs.github.io/iac/team/status/developer/2021/06/04/status-update.html)
 
 <a id="setup"></a>
 ## Setup
@@ -787,6 +788,22 @@ Git is the only VCS provider officially [supported by Puppet Inc.](https://forge
 The includes parameter is only supported when SVN client version is >= 1.6.
 
 For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-vcsrepo/blob/main/metadata.json)
+
+### Response to CVE-2022-24765
+
+The vulnerability described in this CVE could impact users working on multi-user machines.
+A malicious actor could create a `.git` directory above the current working directory causing all git invocations to occur outside of a repository to read its configuration.
+
+For a more in-depth description of this vulnerability, check out [this blog post](https://github.blog/2022-04-12-git-security-vulnerability-announced/).
+
+Fixes were released in Git versions 2.35.2 and 1:2.25.1-1ubuntu3.4 respectively.
+
+VCSRepo users were impacted when running newer versions of Git and managing repositories that were owned by a user or group that differed from the user executing Git.
+
+For example, setting the `owner` parameter on a resource would cause Puppet runs to fail with a `Path /destination/path exists and is not the desired repository.` error.
+
+Impacted users are now advised to use the new `safe_directory` parameter on Git resources.
+Explicitily setting the value to `true` will add the current path specified on the resource to the `safe.directory` git configuration for the current user (global scope) allowing the Puppet run to continue without error.
 
 <a id="development"></a> 
 ## Development

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -61,6 +61,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :keep_local_changes,
           'The provider supports keeping local changes on files tracked by the repository when changing revision'
 
+  feature :safe_directory,
+          'The provider supports setting a safe directory. This will only be used for newer versions of git.'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -112,7 +115,9 @@ Puppet::Type.newtype(:vcsrepo) do
     end
 
     newvalue :absent do
-      provider.destroy
+      if provider.exists?
+        provider.destroy
+      end
     end
 
     newvalue :latest, required_features: [:reference_tracking] do
@@ -297,6 +302,12 @@ Puppet::Type.newtype(:vcsrepo) do
 
   newparam :keep_local_changes do
     desc 'Keep local changes on files tracked by the repository when changing revision'
+    newvalues(true, false)
+    defaultto :false
+  end
+
+  newparam :safe_directory, required_features: [:safe_directory] do
+    desc 'Marks the current directory specified by the path parameter as a safe directory.'
     newvalues(true, false)
     defaultto :false
   end

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -9,6 +9,7 @@ describe 'clones a remote repo' do
 
   after(:all) do
     run_shell("rm -rf #{tmpdir}/testrepo")
+    run_shell("rm -rf #{tmpdir}/testrepo_owner")
     run_shell("rm -rf #{tmpdir}/testrepo_mirror_repo")
   end
 
@@ -225,6 +226,7 @@ describe 'clones a remote repo' do
         provider => git,
         source => "file://#{tmpdir}/testrepo.git",
         owner => 'vagrant',
+        safe_directory => true,
       }
     MANIFEST
     it 'clones a repo' do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -193,6 +193,7 @@ BRANCHES
       expect(provider).to receive(:path_exists?).and_return(true)
       expect(provider).to receive(:path_empty?).and_return(false)
       provider.destroy
+      expect(provider).to receive(:exec_git).with('config', '--global', '--get-all', 'safe.directory')
       expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
       expect(provider).to receive(:update_submodules)
       expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false


### PR DESCRIPTION
After git was patched for [CVE-2022-24765](https://nvd.nist.gov/vuln/detail/CVE-2022-24765) the git binary would fail to execute in a repository that was owned by another user or group.

As of git 2.35.2, you can specify the `safe.directory` configuration or for prior versions define the `GIT_CEILING_DIRECTORIES` environment variable to whitelist known directories.

For users of VCSRepo running newer  of git, there was no obvious way to apply the remediation.

This PR will close #535 by adding a `safe_directory` property to the type, allowing users to explicitly mark a path as 'safe'.

