### PR TITLE
(GH-545) Raise if identity is used with older git

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -622,6 +622,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
 
     if @resource.value(:identity)
+      return raise 'Git version 2.10.0 or higher is required to use the identity parameter.' unless Gem::Version.new(git_version) >= Gem::Version.new('2.10.0')
+
       ssh_opts = {
         IgnoreUnknown: 'IdentityAgent',
         IdentitiesOnly: 'yes',

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -252,7 +252,7 @@ Puppet::Type.newtype(:vcsrepo) do
   end
 
   newparam :identity, required_features: [:ssh_identity] do
-    desc 'SSH identity file'
+    desc 'SSH identity file. Git version 2.10.0 or later is required when using the identity parameter.'
   end
 
   newproperty :module, required_features: [:modules] do


### PR DESCRIPTION
The SSH implementation in this module relies on the GIT_SSH_COMMAND environment variable. This option is only available in versions 2.10.0 and later of Git.

Therefore in in certain cases when consumers have an older version of git installed the module will fail but would lack a descriptive error message.

This PR ensures that we check the git version when the identity parameter is used and raising a descriptive error if the current version is lower than 2.10.0.

Fixes #545