### PR TITLE
(GH-552) Fix home directory evaluation

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -650,10 +650,11 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     exec_args = {
       failonfail: true,
       combine: true,
-      custom_environment: { 'HOME' => Dir.home },
+      custom_environment: { 'HOME' => Etc.getpwuid(Process.uid).dir },
     }
+
     if @resource.value(:user) && @resource.value(:user) != Facter['id'].value
-      exec_args[:custom_environment] = { 'HOME' => Dir.home(@resource.value(:user)) }
+      exec_args[:custom_environment] = { 'HOME' => Etc.getpwnam(@resource.value(:user)).dir }
       exec_args[:uid] = @resource.value(:user)
     end
     Puppet::Util::Execution.execute([:git, args], **exec_args)


### PR DESCRIPTION
Prior to this PR the module would fail when executed under the context of systemd.

This was because Dir.home tries to expand `~` when no UID is passed.
However the HOME environment variable is not available when the agent is executed by systemd resulting in the following error:

`Could not evaluate: couldn't find login name -- expanding ~`

This commit fixes this by reverting to using Etc.getpwuid so that we can retrieve the home dir from the  uid of the current process.

For consistency, retrieval of home dirs for a given user has also been changed to use Etc.getpwnam.

Fixes #552 