### PR TITLE
Add skip_hooks property to vcsrepo 

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -332,11 +332,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
       rescue Puppet::ExecutionFailure
         return :false
       end
-      if d.chomp == '/dev/null'
-        return :true
-      else
-        return :false
-      end
+      return :true if d.chomp == '/dev/null'
+      :false
     end
   end
 

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -332,7 +332,6 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   end
 
   def set_skip_hooks(desired)
-
     current = skip_hooks
     at_path do
       if desired == true && current == false
@@ -687,5 +686,4 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
     Puppet::Util::Execution.execute([:git, args], **exec_args)
   end
-
 end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -19,10 +19,12 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
       end
 
       init_repository
+      set_skip_hooks @resource.value(:skip_hooks)
     else
       clone_repository(default_url, @resource.value(:path))
       update_remotes(@resource.value(:source))
       set_mirror if @resource.value(:ensure) == :mirror && @resource.value(:source).is_a?(Hash)
+      set_skip_hooks @resource.value(:skip_hooks)
 
       if @resource.value(:revision)
         checkout
@@ -685,4 +687,5 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
     Puppet::Util::Execution.execute([:git, args], **exec_args)
   end
+
 end

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -326,9 +326,14 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   end
 
   def skip_hooks
+    git_ver = git_version
+    config_args = ['config']
+    if Gem::Version.new(git_ver) >= Gem::Version.new('1.7.4')
+      config_args.push('--local')
+    end
     at_path do
       begin
-        d = git_with_identity('config', '--local', '--get', 'core.hooksPath')
+        d = git_with_identity(*config_args, '--get', 'core.hooksPath')
       rescue Puppet::ExecutionFailure
         return :false
       end
@@ -338,12 +343,17 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   end
 
   def skip_hooks=(desired)
+    git_ver = git_version
+    config_args = ['config']
+    if Gem::Version.new(git_ver) >= Gem::Version.new('1.7.4')
+      config_args.push('--local')
+    end
     at_path do
       if desired == :true
-        exec_git('config', '--local', 'core.hooksPath', '/dev/null')
+        exec_git(*config_args, 'core.hooksPath', '/dev/null')
       elsif desired == :false
         begin
-          exec_git('config', '--local', '--unset', 'core.hooksPath')
+          exec_git(*config_args, '--unset', 'core.hooksPath')
         rescue Puppet::ExecutionFailure
           next
         end

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -315,10 +315,9 @@ Puppet::Type.newtype(:vcsrepo) do
     defaultto :false
   end
 
-  newproperty :skip_hooks, parent: Puppet::Property::Boolean, required_features: [:hooks_allowed] do
+  newproperty :skip_hooks, required_features: [:hooks_allowed] do
     desc 'Explicitly skip any global hooks for this repository.'
-    newvalues(true, false)
-    defaultto false
+    newvalues(:true, :false)
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -64,6 +64,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :safe_directory,
           'The provider supports setting a safe directory. This will only be used for newer versions of git.'
 
+  feature :hooks_allowed,
+          'The provider supports managing hooks for the repository operations.'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -310,6 +313,12 @@ Puppet::Type.newtype(:vcsrepo) do
     desc 'Marks the current directory specified by the path parameter as a safe directory.'
     newvalues(true, false)
     defaultto :false
+  end
+
+  newproperty :skip_hooks, parent: Puppet::Property::Boolean, required_features: [:hooks_allowed] do
+    desc 'Explicitly skip any global hooks for this repository.'
+    newvalues(true, false)
+    defaultto false
   end
 
   autorequire(:package) do

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -577,7 +577,7 @@ describe 'clones a remote repo' do
 
       it 'clones a repo' do
         # Run it twice and test for idempotency
-        idempotent_apply(pp, debug: true)
+        idempotent_apply(pp)
       end
 
       describe file("#{tmpdir}/testrepo_skip_hooks/.git/config") do
@@ -590,7 +590,7 @@ describe 'clones a remote repo' do
 
       it 'clones a repo' do
         # Run it twice and test for idempotency
-        idempotent_apply(pp, debug: true)
+        idempotent_apply(pp)
       end
 
       describe file("#{tmpdir}/testrepo_skip_hooks/.git/config") do

--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -561,4 +561,41 @@ describe 'clones a remote repo' do
       it { is_expected.to contain 'ref: refs/heads/main' }
     end
   end
+
+  context 'with skip hooks' do
+    pp_template = <<-MANIFEST
+      vcsrepo { "#{tmpdir}/testrepo_skip_hooks":
+        ensure => present,
+        provider => git,
+        source => "file://#{tmpdir}/testrepo.git",
+        skip_hooks => %s,
+      }
+    MANIFEST
+
+    context 'when true' do
+      pp = pp_template % :true
+
+      it 'clones a repo' do
+        # Run it twice and test for idempotency
+        idempotent_apply(pp, debug: true)
+      end
+
+      describe file("#{tmpdir}/testrepo_skip_hooks/.git/config") do
+        it { is_expected.to contain 'hooksPath = /dev/null' }
+      end
+    end
+
+    context 'when false' do
+      pp = pp_template % :false
+
+      it 'clones a repo' do
+        # Run it twice and test for idempotency
+        idempotent_apply(pp, debug: true)
+      end
+
+      describe file("#{tmpdir}/testrepo_skip_hooks/.git/config") do
+        it { is_expected.not_to contain 'hooksPath' }
+      end
+    end
+  end
 end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -607,25 +607,25 @@ BRANCHES
       end
 
       context 'when core.hooksPath not defined' do
-        it 'should define core.hooksPath null' do
+        it 'defines core.hooksPath null' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
           expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end
       end
       context 'when core.hooksPath defined not null' do
-        it 'should define core.hooksPath null' do
+        it 'defines core.hooksPath null' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
           expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end
       end
       context 'when core.hooksPath defined null' do
-        it 'should not modify the config' do
+        it 'does not modify the config' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
           expect(provider).not_to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end
@@ -638,25 +638,25 @@ BRANCHES
       end
 
       context 'when core.hooksPath not defined' do
-        it 'should not modify the config' do
+        it 'does not modify the config' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
           expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end
       end
       context 'when core.hooksPath defined not null' do
-        it 'should not modify the config' do
+        it 'does not modify the config' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
           expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end
       end
       context 'when core.hooksPath defined null' do
-        it 'should unset core.hooksPath' do
+        it 'unsets core.hooksPath' do
           expect(provider).to receive(:exec_git)
-                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
+            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
           expect(provider).to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
           provider.set_skip_hooks(resource.value(:skip_hooks))
         end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -40,6 +40,7 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -54,6 +55,7 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('not_origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -69,6 +71,7 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -83,6 +86,7 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
 
@@ -91,6 +95,7 @@ BRANCHES
         expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remotes)
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -103,6 +108,7 @@ BRANCHES
         expect_chdir
         expect_directory?(false)
         expect(provider).to receive(:exec_git).with('init')
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -127,6 +133,7 @@ BRANCHES
         resource.delete(:revision)
         expect(provider).to receive(:exec_git).with('clone', '--bare', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -140,6 +147,7 @@ BRANCHES
         expect_mkdir
         expect_directory?(false)
         expect(provider).to receive(:exec_git).with('init', '--bare')
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -156,6 +164,7 @@ BRANCHES
         resource.delete(:revision)
         expect(provider).to receive(:exec_git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -180,6 +189,7 @@ BRANCHES
         expect_chdir
         expect(provider).to receive(:exec_git).with('config', 'remote.origin.mirror', 'true')
         expect(provider).to receive(:exec_git).with('config', 'remote.other.mirror', 'true')
+        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -199,6 +209,7 @@ BRANCHES
       expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
       expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
       expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
+      expect(provider).to receive(:set_skip_hooks)
       provider.create
     end
   end
@@ -551,6 +562,7 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'checkout', '--force', resource.value(:revision))
+        expect(provider).to receive(:set_skip_hooks)
 
         allow(provider).to receive(:exec_git).with('--version').and_return '2.13.0'
         expect { provider.create }.not_to raise_error

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -595,4 +595,72 @@ BRANCHES
       provider.update_references
     end
   end
+
+  describe 'set_skip_hooks' do
+    before :each do
+      expect_chdir('/tmp/test')
+    end
+
+    context 'when true' do
+      before :each do
+        resource[:skip_hooks] = true
+      end
+
+      context 'when core.hooksPath not defined' do
+        it 'should define core.hooksPath null' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
+          expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+      context 'when core.hooksPath defined not null' do
+        it 'should define core.hooksPath null' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
+          expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+      context 'when core.hooksPath defined null' do
+        it 'should not modify the config' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
+          expect(provider).not_to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+    end
+
+    context 'when false' do
+      before :each do
+        resource[:skip_hooks] = false
+      end
+
+      context 'when core.hooksPath not defined' do
+        it 'should not modify the config' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
+          expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+      context 'when core.hooksPath defined not null' do
+        it 'should not modify the config' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
+          expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+      context 'when core.hooksPath defined null' do
+        it 'should unset core.hooksPath' do
+          expect(provider).to receive(:exec_git)
+                                .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
+          expect(provider).to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
+          provider.set_skip_hooks(resource.value(:skip_hooks))
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -587,6 +587,7 @@ BRANCHES
   describe 'skip_hooks' do
     before :each do
       expect_chdir('/tmp/test')
+      expect(provider).to receive(:exec_git).with('--version').and_return('1.7.4')
     end
 
     context 'when true' do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -40,7 +40,6 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -55,7 +54,6 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('not_origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -71,7 +69,6 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -86,7 +83,6 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
 
@@ -95,7 +91,6 @@ BRANCHES
         expect(provider).to receive(:exec_git).with('clone', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_submodules)
         expect(provider).to receive(:update_remotes)
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -108,7 +103,6 @@ BRANCHES
         expect_chdir
         expect_directory?(false)
         expect(provider).to receive(:exec_git).with('init')
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -133,7 +127,6 @@ BRANCHES
         resource.delete(:revision)
         expect(provider).to receive(:exec_git).with('clone', '--bare', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -147,7 +140,6 @@ BRANCHES
         expect_mkdir
         expect_directory?(false)
         expect(provider).to receive(:exec_git).with('init', '--bare')
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -164,7 +156,6 @@ BRANCHES
         resource.delete(:revision)
         expect(provider).to receive(:exec_git).with('clone', '--mirror', resource.value(:source), resource.value(:path))
         expect(provider).to receive(:update_remotes)
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -189,7 +180,6 @@ BRANCHES
         expect_chdir
         expect(provider).to receive(:exec_git).with('config', 'remote.origin.mirror', 'true')
         expect(provider).to receive(:exec_git).with('config', 'remote.other.mirror', 'true')
-        expect(provider).to receive(:set_skip_hooks)
         provider.create
       end
     end
@@ -209,7 +199,6 @@ BRANCHES
       expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
       expect(provider).to receive(:exec_git).with('branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
       expect(provider).to receive(:exec_git).with('checkout', '--force', resource.value(:revision))
-      expect(provider).to receive(:set_skip_hooks)
       provider.create
     end
   end
@@ -562,7 +551,6 @@ BRANCHES
         expect(provider).to receive(:update_remote_url).with('origin', resource.value(:source)).and_return false
         expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'branch', '--no-color', '-a').and_return(branch_a_list(resource.value(:revision)))
         expect(provider).to receive(:exec_git).with('-c', 'http.sslVerify=false', 'checkout', '--force', resource.value(:revision))
-        expect(provider).to receive(:set_skip_hooks)
 
         allow(provider).to receive(:exec_git).with('--version').and_return '2.13.0'
         expect { provider.create }.not_to raise_error
@@ -596,7 +584,7 @@ BRANCHES
     end
   end
 
-  describe 'set_skip_hooks' do
+  describe 'skip_hooks' do
     before :each do
       expect_chdir('/tmp/test')
     end
@@ -608,26 +596,14 @@ BRANCHES
 
       context 'when core.hooksPath not defined' do
         it 'defines core.hooksPath null' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
           expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
+          provider.skip_hooks = resource.value(:skip_hooks)
         end
       end
       context 'when core.hooksPath defined not null' do
         it 'defines core.hooksPath null' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
           expect(provider).to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
-        end
-      end
-      context 'when core.hooksPath defined null' do
-        it 'does not modify the config' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
-          expect(provider).not_to receive(:exec_git).with('config', '--local', 'core.hooksPath', '/dev/null')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
+          provider.skip_hooks = resource.value(:skip_hooks)
         end
       end
     end
@@ -637,28 +613,10 @@ BRANCHES
         resource[:skip_hooks] = false
       end
 
-      context 'when core.hooksPath not defined' do
-        it 'does not modify the config' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('none')
-          expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
-        end
-      end
-      context 'when core.hooksPath defined not null' do
-        it 'does not modify the config' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/some/path')
-          expect(provider).not_to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
-        end
-      end
       context 'when core.hooksPath defined null' do
         it 'unsets core.hooksPath' do
-          expect(provider).to receive(:exec_git)
-            .with('config', '--local', '--get', '--default', 'none', 'core.hooksPath').and_return('/dev/null')
           expect(provider).to receive(:exec_git).with('config', '--local', '--unset', 'core.hooksPath')
-          provider.set_skip_hooks(resource.value(:skip_hooks))
+          provider.skip_hooks = resource.value(:skip_hooks)
         end
       end
     end


### PR DESCRIPTION
Add new property `skip_hooks` to control wether the repository should actively ignore configured hooks(local, global or system)

Implemented for the `git` provider

### Problematic

When using `vcsrepo` to manage a git repository, having global git hooks configured can mess with the functionality of the module. If checkout hooks are configured they may make any git checkout operation fail.