### PR TITLE
(GH-560) Consider short and long SHAs

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -526,7 +526,8 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
         return branch
       end
     end
-    current = at_path { git_with_identity('rev-parse', rev).strip }
+    args = [ 'rev-parse', "--short=#{@resource.value(:revision).length}", rev]
+    current = at_path { git_with_identity(*args).strip }
     if @resource.value(:revision) == current
       # if already pointed at desired revision, it must be a SHA, so just return it
       return current


### PR DESCRIPTION
As pointed out in #560, the check for SHA equality only
currently works for long shas which are 40 characters.

If a short SHA with :revision rev-parse HEAD returns a long SHA
therefore rendering the equality check false.

e.g

"cb1eb6" != "cb1eb6bb33eb6889818f5b02aa593b4ff2f8ca33"

This commit updates the args so that rev-parse will always return a SHA
that is the same length as the value provided with the :revision
parameter.

This will cause the check to be true and exit get_revision early as it would
do when both values are 40 characters.