### PR TITLE
fix repeated acceptance tests on the same container

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -427,6 +427,11 @@ describe 'clones a remote repo' do
         groups => 'testuser-ssh',
         managehome => true,
       }
+      file { '/home/testuser-ssh/.ssh':
+        ensure => absent,
+        recurse => true,
+        force => true,
+      }
       MANIFEST
       apply_manifest(pp, catch_failures: true)
 


### PR DESCRIPTION
When `pdk bundle exec rake litmus:acceptance:parallel` is run twice, the second command hangs. This happens because ssh-keygen is waiting for interactive input:
```
/home/testuser-ssh/.ssh/id_rsa already exists.
Overwrite (y/n)?
```

To fix this, ensure that we start out with an empty .ssh directory each time.