### PR TITLE
support per-repo HTTP proxy for the git provider

### DIFF
--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -70,6 +70,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :umask,
           'The provider supports setting umask for repo operations'
 
+  feature :http_proxy,
+          'The provider supports retrieving repos via HTTP/HTTPS over an HTTP/HTTPS proxy'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -331,6 +334,26 @@ Puppet::Type.newtype(:vcsrepo) do
     munge do |value|
       raise Puppet::Error, _('The umask specification is invalid: %{value}') % { value: value.inspect } unless value.match?(%r{^0?[0-7]{1,4}$})
       value.to_i(8)
+    end
+  end
+
+  newparam :http_proxy, required_features: [:http_proxy] do
+    desc 'Sets the HTTP/HTTPS proxy for remote repo access'
+    regex = %r{^https?://\S+$}
+    validate do |value|
+      if value.is_a?(Hash)
+        value.each do |k, v|
+          unless v.match?(regex)
+            raise ArgumentError, "HTTP Proxy for #{k} must be an HTTP/HTTPS URL: #{v}"
+          end
+        end
+      else
+        unless value.match?(regex)
+          raise ArgumentError, "HTTP Proxy must be an HTTP/HTTPS URL: #{value}"
+        end
+      end
+      # Validation passed.
+      super(value)
     end
   end
 


### PR DESCRIPTION
Proxies can be specified either as a single proxy or as one or more per-remote proxies.

Since the proxy config need not be supported for _every_ git command, define a new wrapper function to be used for git operations that need remote access, and then prepend the proxy arguments in that wrapper.

This implementation is better than the previously-documented method of using proxies when:
a. Global configuration is not desired.
b. Initial `git clone` should/must use a proxy.

The previously-documented method is still available for different use cases; reword the original instructions so that they are specified as an alternative rather than the primary method.

Move all proxy information into its own section, since this has become rather large to be included in general git usage.