### PR TITLE
Bring back GIT_SSH support for old git versions <2.10

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -666,26 +666,62 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
     end
 
     if @resource.value(:identity)
-      ssh_opts = {
-        IgnoreUnknown: 'IdentityAgent',
-        IdentitiesOnly: 'yes',
-        IdentityAgent: 'none',
-        PasswordAuthentication: 'no',
-        KbdInteractiveAuthentication: 'no',
-      }
-      ssh_command = "ssh -i #{@resource.value(:identity)} "
-      ssh_command += ssh_opts.map { |option, value| "-o \"#{option} #{value}\"" }.join ' '
+      git_ver = git_version
+      if Gem::Version.new(git_ver) >= Gem::Version.new('2.3.0')
+        # GIT_SSH_COMMAND was introduced in version 2.3.0.
+        git_ssh_with_identity_modern(*args)
+      else
+        git_ssh_with_identity_pre_2_10(*args)
+      end
+    else
+      exec_git(*args)
+    end
+  end
 
+  # @!visibility private
+  def git_ssh_with_identity_modern(*args)
+
+    ssh_opts = {
+      IgnoreUnknown: 'IdentityAgent',
+      IdentitiesOnly: 'yes',
+      IdentityAgent: 'none',
+      PasswordAuthentication: 'no',
+      KbdInteractiveAuthentication: 'no',
+    }
+    ssh_command = "ssh -i #{@resource.value(:identity)} "
+    ssh_command += ssh_opts.map { |option, value| "-o \"#{option} #{value}\"" }.join ' '
+
+    env_git_ssh_command_save = ENV['GIT_SSH_COMMAND']
+    ENV['GIT_SSH_COMMAND'] = ssh_command
+
+    ret = exec_git(*args)
+
+    ENV['GIT_SSH_COMMAND'] = env_git_ssh_command_save
+
+    ret
+  end
+
+  # @!visiblity private
+  def git_ssh_with_identity_pre_2_10(*args)
+    Tempfile.open('git-helper', Puppet[:statedir]) do |f|
+      f.puts '#!/bin/sh'
+      f.puts 'SSH_AUTH_SOCKET='
+      f.puts 'export SSH_AUTH_SOCKET'
+      f.puts 'exec ssh -oStrictHostKeyChecking=no -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no ' \
+        "-oChallengeResponseAuthentication=no -oConnectTimeout=120 -i #{@resource.value(:identity)} $*"
+      f.close
+
+      FileUtils.chmod(0o755, f.path)
+
+      env_git_ssh_save         = ENV['GIT_SSH']
       env_git_ssh_command_save = ENV['GIT_SSH_COMMAND']
-      ENV['GIT_SSH_COMMAND'] = ssh_command
+      ENV['GIT_SSH']         = f.path
 
       ret = exec_git(*args)
 
-      ENV['GIT_SSH_COMMAND'] = env_git_ssh_command_save
+      ENV['GIT_SSH']         = env_git_ssh_save
 
       ret
-    else
-      exec_git(*args)
     end
   end
 


### PR DESCRIPTION
Fixes [MODULES-11111](https://tickets.puppetlabs.com/browse/MODULES-11111)
> vcsrepo : identity doesn't work on EL7
