### PR TITLE
Bring back GIT_SSH support for old git versions

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -702,7 +702,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # @!visiblity private
   def git_ssh_with_identity_ssh_file(*args)
-    Tempfile.open('git-helper', Puppet[:statedir]) do |f|
+    Tempfile.open('git-helper') do |f|
       f.puts '#!/bin/sh'
       f.puts 'SSH_AUTH_SOCKET='
       f.puts 'export SSH_AUTH_SOCKET'


### PR DESCRIPTION
Older versions (<2.3) do not support GIT_SSH_COMMAND yet. Fall back to GIT_SSH with a wrapper script.

Fixes [MODULES-11111](https://tickets.puppetlabs.com/browse/MODULES-11111)
> vcsrepo : identity doesn't work on EL7