### PR TITLE
feat(puppet): wrap rescue inside begin / end block

### DIFF
--- a/lib/facter/vcsrepo_svn_ver.rb
+++ b/lib/facter/vcsrepo_svn_ver.rb
@@ -2,17 +2,19 @@
 
 Facter.add(:vcsrepo_svn_ver) do
   setcode do
-    if Facter.value(:operatingsystem) == 'Darwin' && !File.directory?(Facter::Core::Execution.execute('xcode-select -p'))
-      ''
-    else
-      version = Facter::Core::Execution.execute('svn --version --quiet')
-      if Gem::Version.new(version) > Gem::Version.new('0.0.1')
-        version
-      else
+    begin
+      if Facter.value(:operatingsystem) == 'Darwin' && !File.directory?(Facter::Core::Execution.execute('xcode-select -p'))
         ''
+      else
+        version = Facter::Core::Execution.execute('svn --version --quiet')
+        if Gem::Version.new(version) > Gem::Version.new('0.0.1')
+          version
+        else
+          ''
+        end
       end
+    rescue StandardError
+      ''
     end
-  rescue StandardError
-    ''
   end
 end

--- a/lib/puppet/provider/vcsrepo/bzr.rb
+++ b/lib/puppet/provider/vcsrepo/bzr.rb
@@ -55,9 +55,11 @@ Puppet::Type.type(:vcsrepo).provide(:bzr, parent: Puppet::Provider::Vcsrepo) do
 
   def revision=(desired)
     at_path do
-      bzr('update', '-r', desired)
-    rescue Puppet::ExecutionFailure
-      bzr('update', '-r', desired, ':parent')
+      begin
+        bzr('update', '-r', desired)
+      rescue Puppet::ExecutionFailure
+        bzr('update', '-r', desired, ':parent')
+      end
     end
     update_owner
   end

--- a/lib/puppet/provider/vcsrepo/hg.rb
+++ b/lib/puppet/provider/vcsrepo/hg.rb
@@ -45,10 +45,12 @@ Puppet::Type.type(:vcsrepo).provide(:hg, parent: Puppet::Provider::Vcsrepo) do
 
   def latest
     at_path do
-      hg_wrapper('incoming', '--branch', '.', '--newest-first', '--limit', '1', remote: true)[%r{^changeset:\s+(?:-?\d+):(\S+)}m, 1]
-    rescue Puppet::ExecutionFailure
-      # If there are no new changesets, return the current nodeid
-      revision
+      begin
+        hg_wrapper('incoming', '--branch', '.', '--newest-first', '--limit', '1', remote: true)[%r{^changeset:\s+(?:-?\d+):(\S+)}m, 1]
+      rescue Puppet::ExecutionFailure
+        # If there are no new changesets, return the current nodeid
+        revision
+      end
     end
   end
 


### PR DESCRIPTION
We are using Puppet 5 ( not a choice, not a choice ... ) and we need the latest version with safe_directory.
I had to wrap some rescue inside begin / end block to make it works.