### PR TITLE
Allow specifying tmpdir for git wrapper script

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   has_features :bare_repositories, :reference_tracking, :ssh_identity, :multiple_remotes,
                :user, :depth, :branch, :submodules, :safe_directory, :hooks_allowed,
-               :umask, :http_proxy
+               :umask, :http_proxy, :tmpdir
 
   def create
     check_force
@@ -708,7 +708,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # @!visiblity private
   def git_ssh_with_identity_ssh_file(*args)
-    Tempfile.open('git-helper') do |f|
+    Tempfile.open('git-helper', @resource.value(:tmpdir)) do |f|
       f.puts '#!/bin/sh'
       f.puts 'SSH_AUTH_SOCKET='
       f.puts 'export SSH_AUTH_SOCKET'

--- a/lib/puppet/type/vcsrepo.rb
+++ b/lib/puppet/type/vcsrepo.rb
@@ -73,6 +73,9 @@ Puppet::Type.newtype(:vcsrepo) do
   feature :http_proxy,
           'The provider supports retrieving repos via HTTP/HTTPS over an HTTP/HTTPS proxy'
 
+  feature :tmpdir,
+          'The provider supports setting the temp directory used for wrapper scripts.'
+
   ensurable do
     desc 'Ensure the version control repository.'
     attr_accessor :latest
@@ -346,6 +349,10 @@ Puppet::Type.newtype(:vcsrepo) do
       # Validation passed.
       super(value)
     end
+  end
+
+  newparam :tmpdir, required_features: [:tmpdir] do
+    desc 'The temp directory used for wrapper scripts.'
   end
 
   autorequire(:package) do

--- a/spec/unit/puppet/provider/vcsrepo/git_spec.rb
+++ b/spec/unit/puppet/provider/vcsrepo/git_spec.rb
@@ -689,4 +689,28 @@ BRANCHES
       end
     end
   end
+
+  describe 'tmpdir' do
+    before(:each) do
+      resource[:source] = '/path/to/source'
+      resource[:identity] = '/path/to/identity'
+      expect(Dir).to receive(:chdir).with('/tmp/test').at_least(:once).and_yield
+      expect(provider).to receive(:exec_git).with('--version').and_return('1.8.3.1')
+    end
+
+    context 'when set' do
+      it 'uses tmpdir' do
+        resource[:tmpdir] = '/custom_tmp'
+        expect(Tempfile).to receive(:open).with('git-helper', '/custom_tmp')
+        expect { provider.set_mirror }.not_to raise_error
+      end
+    end
+
+    context 'when unset' do
+      it 'uses default' do
+        expect(Tempfile).to receive(:open).with('git-helper', nil)
+        expect { provider.set_mirror }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
On systems with a git version too old to support the `GIT_SSH_COMMAND`, a git wrapper script is created in the default temp directory. If that filesystem is mounted `noexec`, git is unable to execute the wrapper script:

```
Error: Execution of 'git clone git@github.com:org/repo.git /repo_dir' returned 128: Cloning into '/repo_dir'...
fatal: cannot exec '/tmp/git-helper20230607-525-1fvzyp1': Permission denied
````

This was solved in https://github.com/puppetlabs/puppetlabs-vcsrepo/commit/7f97a76f4682a7c1d5bfbbc3cd5a6dd9523b1d96 by using the Puppet `statedir` instead of the default temp directory, but this was later reverted in https://github.com/puppetlabs/puppetlabs-vcsrepo/commit/684200247c33e42f095f9478033b1d2a50bbbab0.

This PR enables specifying the directory used for the wrapper script.