### PR TITLE
Fix an issue with stash

### DIFF
--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -505,7 +505,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
 
   # @!visibility private
   def stash
-    at_path { git_with_identity('stash', 'save') }
+    at_path { git_with_identity('stash', 'push') }
   end
 
   # @!visibility private

--- a/lib/puppet/provider/vcsrepo/git.rb
+++ b/lib/puppet/provider/vcsrepo/git.rb
@@ -425,7 +425,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
   def checkout(revision = @resource.value(:revision))
     has_changes = uncommitted_changes?
     keep_local_changes = @resource.value(:keep_local_changes)
-    stash if has_changes == :true && keep_local_changes == :true
+    stash if has_changes && keep_local_changes == :true
     if !local_branch_revision?(revision) && remote_branch_revision?(revision)
       # non-locally existant branches (perhaps switching to a branch that has never been checked out)
       at_path { git_with_identity('checkout', '--force', '-b', revision, '--track', "#{@resource.value(:remote)}/#{revision}") }
@@ -433,7 +433,7 @@ Puppet::Type.type(:vcsrepo).provide(:git, parent: Puppet::Provider::Vcsrepo) do
       # tags, locally existant branches (perhaps outdated), and shas
       at_path { git_with_identity('checkout', '--force', revision) }
     end
-    unstash if has_changes == :true && keep_local_changes == :true
+    unstash if has_changes && keep_local_changes == :true
   end
 
   # @!visibility private


### PR DESCRIPTION
## Summary
If you use this to clone a new repo but also have `keep_local_changes => true` set then the `git stash pop` will fail with an error. This corrects the problem.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)