### PR TITLE
Enhancement/gh 624  syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v6.1.1](https://github.com/puppetlabs/puppetlabs-vcsrepo/tree/v6.1.1) - 2023-06-13
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/v6.1.0...v6.1.1)
+
+### Added
+
+- enhancement/gh_624--syntax_error, catch syntax errors, suggest upgrade to puppet client
+
 ## [v6.1.0](https://github.com/puppetlabs/puppetlabs-vcsrepo/tree/v6.1.0) - 2023-06-13
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-vcsrepo/compare/v6.0.1...v6.1.0)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The vcsrepo module does not install any VCS software for you. You must install a
 
 Like Puppet in general, the vcsrepo module does not automatically create parent directories for the files it manages. Set up any needed directory structures before you start.
 
+When running puppet v6 and perhaps older installations on the client machine, with v6.1.0 of this module, a known syntax error occurs which can be resolved by an upgrade on the client to puppet 7.  See: https://github.com/puppetlabs/puppetlabs-vcsrepo/issues/624#issuecomment-1770623768 
+
 <a id="beginning-with-vcsrepo"></a>
 ### Beginning with vcsrepo
 

--- a/lib/puppet/provider/vcsrepo/cvs.rb
+++ b/lib/puppet/provider/vcsrepo/cvs.rb
@@ -74,7 +74,12 @@ Puppet::Type.type(:vcsrepo).provide(:cvs, parent: Puppet::Provider::Vcsrepo) do
       if File.exist?(tag_file)
         contents = File.read(tag_file).strip
         # NOTE: Doesn't differentiate between N and T entries
-        @rev = contents[1..]
+        # https://stackify.com/rescue-exceptions-ruby/
+        begin
+          @rev = contents[1..]
+        rescue 'syntax error'
+          p "encountered syntax error at line 79.  Known issue, resolved with upgrade puppet -> ^7 on client.  See: https://github.com/puppetlabs/puppetlabs-vcsrepo/issues/624"
+        end
       else
         @rev = 'HEAD'
       end

--- a/lib/puppet/provider/vcsrepo/cvs.rb
+++ b/lib/puppet/provider/vcsrepo/cvs.rb
@@ -74,7 +74,6 @@ Puppet::Type.type(:vcsrepo).provide(:cvs, parent: Puppet::Provider::Vcsrepo) do
       if File.exist?(tag_file)
         contents = File.read(tag_file).strip
         # NOTE: Doesn't differentiate between N and T entries
-        # https://stackify.com/rescue-exceptions-ruby/
         begin
           @rev = contents[1..]
         rescue 'syntax error'


### PR DESCRIPTION
## Summary
Catch a certain syntax error, recommend an upgrade to client side puppet version => ^7
New documentation in README.md, CHANGELOG.md, and 
syntax error exception caught in lib/puppet/provider/vcsrepo/cvs.rb
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)

Using puppet6 on the client machine, elicits the syntax error documented at:
https://github.com/puppetlabs/puppetlabs-vcsrepo/issues/624 

- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)