### PR TITLE
Fix acceptance test on Ubuntu ARM

### DIFF
--- a/spec/acceptance/clone_repo_spec.rb
+++ b/spec/acceptance/clone_repo_spec.rb
@@ -453,7 +453,7 @@ describe 'clones a remote repo' do
 
       # copy public key to authorized_keys
       run_shell('cat /home/testuser-ssh/.ssh/id_rsa.pub > /home/testuser-ssh/.ssh/authorized_keys')
-      run_shell('echo -e "Host localhost\n\tStrictHostKeyChecking no\n" > /home/testuser-ssh/.ssh/config')
+      run_shell('printf "Host localhost\n\tStrictHostKeyChecking no\n" > /home/testuser-ssh/.ssh/config')
       run_shell('chown -R testuser-ssh:testuser-ssh /home/testuser-ssh/.ssh')
       run_shell('rm -rf /var/run/nologin')
     end


### PR DESCRIPTION
POSIX does not define `-e` as a valid option for echo(1).  Rely on printf(1) instead.

This fix acceptance tests on Ubuntu ARM where echo(1) outputs `-e` causing an invalid configuration:

```
/home/testuser-ssh/.ssh/config: line 1: Bad configuration option: -e
```
