### PR TITLE
(CAT-2053) add testrepo.git to safe.directory

### DIFF
--- a/spec/acceptance/files/create_git_repo.sh
+++ b/spec/acceptance/files/create_git_repo.sh
@@ -35,6 +35,7 @@ git checkout main
 cd ..
 
 git --git-dir=testrepo/.git config core.bare true
+git config --system --add safe.directory $(pwd)/testrepo.git
 cp -r testrepo/.git testrepo.git
 rm -rf testrepo
 cd testrepo.git


### PR DESCRIPTION
## Summary
The nightly build is failing with the new version of Git because testrepo.git is not recognized as a safe directory. In this PR, we are addressing the issue by adding testrepo.git to the safe directory at the system level.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)